### PR TITLE
Streamlining codebase v1 - Round 1

### DIFF
--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -43,78 +43,103 @@ void MhiClimate::dump_config() {
 void MhiClimate::update_status(ACStatus status, int value) {
 
     static int mode_tmp = 0xff;
+    bool dirty = false;
 
-    
     ESP_LOGD(TAG, "received status=%i value=%i power=%i", status, value, this->power_);
-
-    if (this->power_ == power_off) {
-        // Workaround for status after reboot
-        this->mode = climate::CLIMATE_MODE_OFF;
-        this->publish_state();
-    }
 
     switch (status) {
     case status_power:
         if (value == power_on) {
-            this->power_ = power_on;
+            if (this->power_ != power_on) {
+                this->power_ = power_on;
+                dirty = true;
+            }
             update_status(status_mode, mode_tmp);
         } else {
-            this->power_ = power_off;
-            this->mode = climate::CLIMATE_MODE_OFF;
-            this->publish_state();
+            if (this->power_ != power_off) {
+                this->power_ = power_off;
+                dirty = true;
+            }
+            if (this->mode != climate::CLIMATE_MODE_OFF) {
+                this->mode = climate::CLIMATE_MODE_OFF;
+                dirty = true;
+            }
         }
         break;
+
     case status_mode:
         mode_tmp = value;
+        [[fallthrough]];
     case opdata_mode:
-    case erropdata_mode:
+    case erropdata_mode: {
+        auto new_mode = this->mode;
+
         switch (value) {
-        case mode_auto:          
+        case mode_auto:
             if (status != erropdata_mode && this->power_ > 0) {
-                this->mode = climate::CLIMATE_MODE_HEAT_COOL;
+                new_mode = climate::CLIMATE_MODE_HEAT_COOL;
             } else {
-                this->mode = climate::CLIMATE_MODE_OFF;
+                new_mode = climate::CLIMATE_MODE_OFF;
             }
             break;
         case mode_dry:
-            this->mode = climate::CLIMATE_MODE_DRY;
+            new_mode = climate::CLIMATE_MODE_DRY;
             break;
         case mode_cool:
-            this->mode = climate::CLIMATE_MODE_COOL;
+            new_mode = climate::CLIMATE_MODE_COOL;
             break;
         case mode_fan:
-            this->mode = climate::CLIMATE_MODE_FAN_ONLY;
+            new_mode = climate::CLIMATE_MODE_FAN_ONLY;
             break;
         case mode_heat:
-            this->mode = climate::CLIMATE_MODE_HEAT;
+            new_mode = climate::CLIMATE_MODE_HEAT;
             break;
         default:
             ESP_LOGD(TAG, "unknown status mode value %i", value);
+            break;
         }
-        this->publish_state();
+
+        if (this->mode != new_mode) {
+            this->mode = new_mode;
+            dirty = true;
+        }
         break;
-    case status_fan:
+    }
+
+    case status_fan: {
+        auto new_fan_mode = this->fan_mode;
+
         switch (value) {
         case 0:
-            this->fan_mode = climate::CLIMATE_FAN_QUIET;
+            new_fan_mode = climate::CLIMATE_FAN_QUIET;
             break;
         case 1:
-            this->fan_mode = climate::CLIMATE_FAN_LOW;
+            new_fan_mode = climate::CLIMATE_FAN_LOW;
             break;
         case 2:
-            this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
+            new_fan_mode = climate::CLIMATE_FAN_MEDIUM;
             break;
         case 6:
-            this->fan_mode = climate::CLIMATE_FAN_HIGH;
+            new_fan_mode = climate::CLIMATE_FAN_HIGH;
             break;
         case 7:
-            this->fan_mode = climate::CLIMATE_FAN_AUTO;
+            new_fan_mode = climate::CLIMATE_FAN_AUTO;
+            break;
+        default:
             break;
         }
-        this->publish_state();
+
+        if (this->fan_mode != new_fan_mode) {
+            this->fan_mode = new_fan_mode;
+            dirty = true;
+        }
         break;
-    case status_vanes:
-        // Vanes Up Down, also known as Vertical
+    }
+
+    case status_vanes: {
+        auto new_swing_mode = this->swing_mode;
+        int new_vanes_pos_old_state = this->vanes_pos_old_state_;
+
         if (this->vanesLR_pos_state_ == vanesLR_swing) {
             switch (value) {
                 case vanes_unknown:
@@ -122,34 +147,48 @@ void MhiClimate::update_status(ACStatus status, int value) {
                 case vanes_2:
                 case vanes_3:
                 case vanes_4:
-                    this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
-                    this->vanes_pos_old_state_ = value;
+                    new_swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
+                    new_vanes_pos_old_state = value;
                     break;
                 case vanes_swing:
-                    this->swing_mode = climate::CLIMATE_SWING_BOTH;
+                    new_swing_mode = climate::CLIMATE_SWING_BOTH;
                     break;
             }
-        }
-        else {
+        } else {
             switch (value) {
                 case vanes_unknown:
                 case vanes_1:
                 case vanes_2:
                 case vanes_3:
                 case vanes_4:
-                    this->swing_mode = climate::CLIMATE_SWING_OFF;
-                    this->vanes_pos_old_state_ = value;
+                    new_swing_mode = climate::CLIMATE_SWING_OFF;
+                    new_vanes_pos_old_state = value;
                     break;
                 case vanes_swing:
-                    this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
+                    new_swing_mode = climate::CLIMATE_SWING_VERTICAL;
                     break;
             }
-
         }
-        this->vanes_pos_state_ = value;
-        this->publish_state();
+
+        if (this->swing_mode != new_swing_mode) {
+            this->swing_mode = new_swing_mode;
+            dirty = true;
+        }
+        if (this->vanes_pos_old_state_ != new_vanes_pos_old_state) {
+            this->vanes_pos_old_state_ = new_vanes_pos_old_state;
+            dirty = true;
+        }
+        if (this->vanes_pos_state_ != value) {
+            this->vanes_pos_state_ = value;
+            dirty = true;
+        }
         break;
-    case status_vanesLR:
+    }
+
+    case status_vanesLR: {
+        auto new_swing_mode = this->swing_mode;
+        int new_vanesLR_pos_old_state = this->vanesLR_pos_old_state_;
+
         if (this->vanes_pos_state_ == vanes_swing) {
             switch (value) {
                 case vanesLR_1:
@@ -159,15 +198,14 @@ void MhiClimate::update_status(ACStatus status, int value) {
                 case vanesLR_5:
                 case vanesLR_6:
                 case vanesLR_7:
-                    this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
-                    this->vanesLR_pos_old_state_ = value;
+                    new_swing_mode = climate::CLIMATE_SWING_VERTICAL;
+                    new_vanesLR_pos_old_state = value;
                     break;
                 case vanesLR_swing:
-                    this->swing_mode = climate::CLIMATE_SWING_BOTH;
+                    new_swing_mode = climate::CLIMATE_SWING_BOTH;
                     break;
             }
-        }
-        else {
+        } else {
             switch (value) {
                 case vanesLR_1:
                 case vanesLR_2:
@@ -176,48 +214,68 @@ void MhiClimate::update_status(ACStatus status, int value) {
                 case vanesLR_5:
                 case vanesLR_6:
                 case vanesLR_7:
-                    this->swing_mode = climate::CLIMATE_SWING_OFF;
-                    this->vanesLR_pos_old_state_ = value;
+                    new_swing_mode = climate::CLIMATE_SWING_OFF;
+                    new_vanesLR_pos_old_state = value;
                     break;
                 case vanesLR_swing:
-                    this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
+                    new_swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
                     break;
             }
-
         }
-        this->publish_state();
-        this->vanesLR_pos_state_ = value;
+
+        if (this->swing_mode != new_swing_mode) {
+            this->swing_mode = new_swing_mode;
+            dirty = true;
+        }
+        if (this->vanesLR_pos_old_state_ != new_vanesLR_pos_old_state) {
+            this->vanesLR_pos_old_state_ = new_vanesLR_pos_old_state;
+            dirty = true;
+        }
+        if (this->vanesLR_pos_state_ != value) {
+            this->vanesLR_pos_state_ = value;
+            dirty = true;
+        }
         break;
-    case status_troom:
-        // Calculate the temperature and apply the offset for 0.5°C steps
-        this->current_temperature = ((value - 61) / 4.0) - this->temperature_offset_;
-        this->publish_state();
+    }
+
+    case status_troom: {
+        float new_current_temperature = ((value - 61) / 4.0f) - this->temperature_offset_;
+        if (std::isnan(this->current_temperature) ||
+            fabs(this->current_temperature - new_current_temperature) > 0.01f) {
+            this->current_temperature = new_current_temperature;
+            dirty = true;
+        }
         break;
+    }
 
     case status_tsetpoint: {
-        float ac_setpoint = (value & 0x7f) / 2.0;
+        float ac_setpoint = (value & 0x7f) / 2.0f;
 
-        // If we are using an offset, check if the AC's update is just an
-        // echo of the command we already sent (our target + our offset).
-        if (this->temperature_offset_ != 0.0 && 
-            fabs(ac_setpoint - (this->target_temperature + this->temperature_offset_)) < 0.1) {
-            
-            // This is an expected echo. Do nothing to prevent overwriting our state.
+        if (this->temperature_offset_ != 0.0f &&
+            fabs(ac_setpoint - (this->target_temperature + this->temperature_offset_)) < 0.1f) {
             ESP_LOGD(TAG, "Ignoring tsetpoint echo from AC: %.1f", ac_setpoint);
             break;
         }
 
-        // If it's not an echo, it's a new value from the remote.
-        // Update the target temperature and reset the offset.
         ESP_LOGI(TAG, "Remote setpoint change detected. Updating target to %.1f", ac_setpoint);
-        this->target_temperature = ac_setpoint;
-        this->temperature_offset_ = 0.0;
-        this->publish_state();
+
+        if (fabs(this->target_temperature - ac_setpoint) > 0.01f) {
+            this->target_temperature = ac_setpoint;
+            dirty = true;
+        }
+        if (this->temperature_offset_ != 0.0f) {
+            this->temperature_offset_ = 0.0f;
+            dirty = true;
+        }
         break;
     }
+
     default:
-        // skip these values as they are not used currently
         break;
+    }
+
+    if (dirty) {
+        this->publish_state();
     }
 }
 

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -11,28 +11,36 @@ static const char *TAG = "mhi.climate";
 void MhiClimate::setup() {
     this->power_ = power_off;
     this->current_temperature = NAN;
-    // restore set points
+
+    float restored_target_temperature = NAN;
     auto restore = this->restore_state_();
     if (restore.has_value()) {
-        restore->apply(this);
-    } else {
-        // restore from defaults
-        this->mode = climate::CLIMATE_MODE_OFF;
-        // initialize target temperature to some value so that it's not NAN
-        this->target_temperature = roundf(clamp(
-            this->current_temperature, this->minimum_temperature_, this->maximum_temperature_));
-        this->fan_mode = climate::CLIMATE_FAN_AUTO;
-        this->swing_mode = climate::CLIMATE_SWING_OFF;
+        restored_target_temperature = restore->target_temperature;
     }
-    // Never send nan to HA
-    if (std::isnan(this->target_temperature))
-        this->target_temperature = 20;
+
+    // Do not restore live operating state on boot.
+    // The indoor unit is the source of truth, and if it is off at startup
+    // we may not immediately receive enough status updates to correct a stale
+    // restored mode/fan/swing state from HA/NVS.
+    this->mode = climate::CLIMATE_MODE_OFF;
+    this->fan_mode = climate::CLIMATE_FAN_AUTO;
+    this->swing_mode = climate::CLIMATE_SWING_OFF;
+
+    if (!std::isnan(restored_target_temperature)) {
+        this->target_temperature = restored_target_temperature;
+    } else {
+        this->target_temperature = 20.0f;
+    }
 
     this->vanesLR_pos_old_state_ = 4;
     this->vanes_pos_old_state_ = 4;
 
     this->platform_ = this->parent_;
     this->platform_->add_listener(this);
+
+    // Publish a safe startup state instead of a potentially stale restored
+    // running state. Real device telemetry will correct this once received.
+    this->publish_state();
 }
 
 void MhiClimate::dump_config() {
@@ -278,11 +286,11 @@ void MhiClimate::update_status(ACStatus status, int value) {
 void MhiClimate::control(const climate::ClimateCall &call) {
     if (call.get_target_temperature().has_value()) {
         float target_temp = *call.get_target_temperature();
-        this->target_temperature = target_temp; // Store the user's desired temp
+        this->target_temperature = target_temp;
 
         ESP_LOGD(TAG, "MhiClimate::control - get_target_temperature - New target_temperature: %.1f°C", target_temp);
 
-        const float ac_unit_min_temp = 18.0f; // Hardware minimum for the AC unit
+        const float ac_unit_min_temp = 18.0f;
 
         float setpoint = ceil(target_temp);
         if (setpoint < ac_unit_min_temp)
@@ -381,7 +389,6 @@ void MhiClimate::control(const climate::ClimateCall &call) {
     this->publish_state();
 }
 
-/// Return the traits of this controller.
 #if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 11, 0)
 climate::ClimateTraits MhiClimate::traits() {
     auto traits = climate::ClimateTraits();

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -2,11 +2,42 @@
 #include "esphome/core/log.h"
 #include "esphome/core/version.h"
 #include "mhi_climate.h"
+#include "../mhi_time.h"
 
 namespace esphome {
 namespace mhi {
 
 static const char *TAG = "mhi.climate";
+
+bool MhiClimate::pending_window_active_() const {
+    return (mhi_now_ms() - this->pending_until_ms_) <= 0x7FFFFFFFU &&
+           mhi_now_ms() < this->pending_until_ms_;
+}
+
+void MhiClimate::start_pending_window_() {
+    this->pending_until_ms_ = mhi_now_ms() + kCommandSettleWindowMs;
+}
+
+void MhiClimate::clear_expired_pending_() {
+    if (this->pending_window_active_()) {
+        return;
+    }
+
+    this->pending_power_valid_ = false;
+    this->pending_mode_valid_ = false;
+    this->pending_target_temperature_valid_ = false;
+    this->pending_fan_valid_ = false;
+    this->pending_swing_valid_ = false;
+}
+
+void MhiClimate::clear_all_pending_() {
+    this->pending_power_valid_ = false;
+    this->pending_mode_valid_ = false;
+    this->pending_target_temperature_valid_ = false;
+    this->pending_fan_valid_ = false;
+    this->pending_swing_valid_ = false;
+    this->pending_until_ms_ = 0;
+}
 
 void MhiClimate::setup() {
     this->power_ = power_off;
@@ -18,10 +49,6 @@ void MhiClimate::setup() {
         restored_target_temperature = restore->target_temperature;
     }
 
-    // Do not restore live operating state on boot.
-    // The indoor unit is the source of truth, and if it is off at startup
-    // we may not immediately receive enough status updates to correct a stale
-    // restored mode/fan/swing state from HA/NVS.
     this->mode = climate::CLIMATE_MODE_OFF;
     this->fan_mode = climate::CLIMATE_FAN_AUTO;
     this->swing_mode = climate::CLIMATE_SWING_OFF;
@@ -38,8 +65,6 @@ void MhiClimate::setup() {
     this->platform_ = this->parent_;
     this->platform_->add_listener(this);
 
-    // Publish a safe startup state instead of a potentially stale restored
-    // running state. Real device telemetry will correct this once received.
     this->publish_state();
 }
 
@@ -48,12 +73,26 @@ void MhiClimate::dump_config() {
 }
 
 void MhiClimate::update_status(ACStatus status, int value) {
+    this->clear_expired_pending_();
+
     static int mode_tmp = 0xff;
     bool dirty = false;
 
     switch (status) {
-    case status_power:
-        if (value == power_on) {
+    case status_power: {
+        const ACPower new_power = (value == power_on) ? power_on : power_off;
+
+        if (this->pending_power_valid_ && this->pending_window_active_() &&
+            new_power != this->pending_power_) {
+            ESP_LOGV(TAG, "Suppressing stale power status %d during pending window", value);
+            break;
+        }
+
+        if (this->pending_power_valid_ && new_power == this->pending_power_) {
+            this->pending_power_valid_ = false;
+        }
+
+        if (new_power == power_on) {
             if (this->power_ != power_on) {
                 this->power_ = power_on;
                 dirty = true;
@@ -68,8 +107,10 @@ void MhiClimate::update_status(ACStatus status, int value) {
                 this->mode = climate::CLIMATE_MODE_OFF;
                 dirty = true;
             }
+            this->pending_mode_valid_ = false;
         }
         break;
+    }
 
     case status_mode:
         mode_tmp = value;
@@ -103,6 +144,16 @@ void MhiClimate::update_status(ACStatus status, int value) {
             break;
         }
 
+        if (this->pending_mode_valid_ && this->pending_window_active_() &&
+            new_mode != this->pending_mode_) {
+            ESP_LOGV(TAG, "Suppressing stale mode status %d during pending window", value);
+            break;
+        }
+
+        if (this->pending_mode_valid_ && new_mode == this->pending_mode_) {
+            this->pending_mode_valid_ = false;
+        }
+
         if (this->mode != new_mode) {
             this->mode = new_mode;
             dirty = true;
@@ -131,6 +182,16 @@ void MhiClimate::update_status(ACStatus status, int value) {
             break;
         default:
             break;
+        }
+
+        if (this->pending_fan_valid_ && this->pending_window_active_() &&
+            new_fan_mode != this->pending_fan_mode_) {
+            ESP_LOGV(TAG, "Suppressing stale fan status %d during pending window", value);
+            break;
+        }
+
+        if (this->pending_fan_valid_ && new_fan_mode == this->pending_fan_mode_) {
+            this->pending_fan_valid_ = false;
         }
 
         if (this->fan_mode != new_fan_mode) {
@@ -172,6 +233,16 @@ void MhiClimate::update_status(ACStatus status, int value) {
                     new_swing_mode = climate::CLIMATE_SWING_VERTICAL;
                     break;
             }
+        }
+
+        if (this->pending_swing_valid_ && this->pending_window_active_() &&
+            new_swing_mode != this->pending_swing_mode_) {
+            ESP_LOGV(TAG, "Suppressing stale vertical vanes status %d during pending window", value);
+            break;
+        }
+
+        if (this->pending_swing_valid_ && new_swing_mode == this->pending_swing_mode_) {
+            this->pending_swing_valid_ = false;
         }
 
         if (this->swing_mode != new_swing_mode) {
@@ -227,6 +298,16 @@ void MhiClimate::update_status(ACStatus status, int value) {
             }
         }
 
+        if (this->pending_swing_valid_ && this->pending_window_active_() &&
+            new_swing_mode != this->pending_swing_mode_) {
+            ESP_LOGV(TAG, "Suppressing stale horizontal vanes status %d during pending window", value);
+            break;
+        }
+
+        if (this->pending_swing_valid_ && new_swing_mode == this->pending_swing_mode_) {
+            this->pending_swing_valid_ = false;
+        }
+
         if (this->swing_mode != new_swing_mode) {
             this->swing_mode = new_swing_mode;
             dirty = true;
@@ -261,7 +342,16 @@ void MhiClimate::update_status(ACStatus status, int value) {
             break;
         }
 
-        ESP_LOGV(TAG, "Remote setpoint change detected. Updating target to %.1f", ac_setpoint);
+        if (this->pending_target_temperature_valid_ && this->pending_window_active_() &&
+            fabs(ac_setpoint - this->pending_target_temperature_) > 0.11f) {
+            ESP_LOGV(TAG, "Suppressing stale tsetpoint %.1f during pending window", ac_setpoint);
+            break;
+        }
+
+        if (this->pending_target_temperature_valid_ &&
+            fabs(ac_setpoint - this->pending_target_temperature_) <= 0.11f) {
+            this->pending_target_temperature_valid_ = false;
+        }
 
         if (fabs(this->target_temperature - ac_setpoint) > 0.01f) {
             this->target_temperature = ac_setpoint;
@@ -278,21 +368,28 @@ void MhiClimate::update_status(ACStatus status, int value) {
         break;
     }
 
+    if (!this->pending_window_active_()) {
+        this->clear_expired_pending_();
+    } else if (!this->pending_power_valid_ && !this->pending_mode_valid_ &&
+               !this->pending_target_temperature_valid_ && !this->pending_fan_valid_ &&
+               !this->pending_swing_valid_) {
+        this->pending_until_ms_ = 0;
+    }
+
     if (dirty) {
         this->publish_state();
     }
 }
 
 void MhiClimate::control(const climate::ClimateCall &call) {
+    bool had_change = false;
+
     if (call.get_target_temperature().has_value()) {
         float target_temp = *call.get_target_temperature();
         this->target_temperature = target_temp;
 
-        ESP_LOGD(TAG, "MhiClimate::control - get_target_temperature - New target_temperature: %.1f°C", target_temp);
-
         const float ac_unit_min_temp = 18.0f;
-
-        float setpoint = ceil(target_temp);
+        float setpoint = ceilf(target_temp);
         if (setpoint < ac_unit_min_temp)
             setpoint = ac_unit_min_temp;
 
@@ -304,7 +401,12 @@ void MhiClimate::control(const climate::ClimateCall &call) {
         this->temperature_offset_ = offset;
         this->platform_->set_tsetpoint(setpoint);
 
-        ESP_LOGD(TAG, "MhiClimate::control - get_target_temperature - set_tsetpoint %f, set_offset %f", setpoint, offset);
+        this->pending_target_temperature_valid_ = true;
+        this->pending_target_temperature_ = setpoint;
+        had_change = true;
+
+        ESP_LOGD(TAG, "Requested target_temperature %.1f°C (AC setpoint %.1f°C, offset %.1f°C)",
+                 target_temp, setpoint, offset);
     }
 
     if (call.get_mode().has_value()) {
@@ -335,6 +437,12 @@ void MhiClimate::control(const climate::ClimateCall &call) {
 
         this->platform_->set_power(power_);
         this->platform_->set_mode(mode_);
+
+        this->pending_power_valid_ = true;
+        this->pending_power_ = power_;
+        this->pending_mode_valid_ = true;
+        this->pending_mode_ = this->mode;
+        had_change = true;
     }
 
     if (call.get_fan_mode().has_value()) {
@@ -360,6 +468,9 @@ void MhiClimate::control(const climate::ClimateCall &call) {
         }
 
         this->platform_->set_fan(fan_);
+        this->pending_fan_valid_ = true;
+        this->pending_fan_mode_ = this->fan_mode.value();
+        had_change = true;
     }
 
     if (call.get_swing_mode().has_value()) {
@@ -376,14 +487,24 @@ void MhiClimate::control(const climate::ClimateCall &call) {
         case climate::CLIMATE_SWING_HORIZONTAL:
             vanesLR_ = vanesLR_swing;
             break;
-        default:
         case climate::CLIMATE_SWING_BOTH:
+        default:
             vanesLR_ = vanesLR_swing;
             vanes_ = vanes_swing;
             break;
         }
+
         this->platform_->set_vanesLR(vanesLR_);
         this->platform_->set_vanes(vanes_);
+        this->pending_swing_valid_ = true;
+        this->pending_swing_mode_ = this->swing_mode;
+        had_change = true;
+    }
+
+    if (had_change) {
+        this->start_pending_window_();
+    } else {
+        this->clear_expired_pending_();
     }
 
     this->publish_state();

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -6,7 +6,7 @@
 namespace esphome {
 namespace mhi {
 
-static const char* TAG = "mhi.climate";
+static const char *TAG = "mhi.climate";
 
 void MhiClimate::setup() {
     this->power_ = power_off;
@@ -33,7 +33,6 @@ void MhiClimate::setup() {
 
     this->platform_ = this->parent_;
     this->platform_->add_listener(this);
-    
 }
 
 void MhiClimate::dump_config() {
@@ -41,11 +40,8 @@ void MhiClimate::dump_config() {
 }
 
 void MhiClimate::update_status(ACStatus status, int value) {
-
     static int mode_tmp = 0xff;
     bool dirty = false;
-
-    ESP_LOGD(TAG, "received status=%i value=%i power=%i", status, value, this->power_);
 
     switch (status) {
     case status_power:
@@ -95,7 +91,7 @@ void MhiClimate::update_status(ACStatus status, int value) {
             new_mode = climate::CLIMATE_MODE_HEAT;
             break;
         default:
-            ESP_LOGD(TAG, "unknown status mode value %i", value);
+            ESP_LOGV(TAG, "unknown status mode value %i", value);
             break;
         }
 
@@ -253,11 +249,11 @@ void MhiClimate::update_status(ACStatus status, int value) {
 
         if (this->temperature_offset_ != 0.0f &&
             fabs(ac_setpoint - (this->target_temperature + this->temperature_offset_)) < 0.1f) {
-            ESP_LOGD(TAG, "Ignoring tsetpoint echo from AC: %.1f", ac_setpoint);
+            ESP_LOGV(TAG, "Ignoring tsetpoint echo from AC: %.1f", ac_setpoint);
             break;
         }
 
-        ESP_LOGI(TAG, "Remote setpoint change detected. Updating target to %.1f", ac_setpoint);
+        ESP_LOGV(TAG, "Remote setpoint change detected. Updating target to %.1f", ac_setpoint);
 
         if (fabs(this->target_temperature - ac_setpoint) > 0.01f) {
             this->target_temperature = ac_setpoint;
@@ -279,7 +275,7 @@ void MhiClimate::update_status(ACStatus status, int value) {
     }
 }
 
-void MhiClimate::control(const climate::ClimateCall& call) {
+void MhiClimate::control(const climate::ClimateCall &call) {
     if (call.get_target_temperature().has_value()) {
         float target_temp = *call.get_target_temperature();
         this->target_temperature = target_temp; // Store the user's desired temp
@@ -292,7 +288,7 @@ void MhiClimate::control(const climate::ClimateCall& call) {
         if (setpoint < ac_unit_min_temp)
             setpoint = ac_unit_min_temp;
 
-        float offset = 0.0;
+        float offset = 0.0f;
         if (this->temperature_offset_enabled_) {
             offset = setpoint - target_temp;
         }
@@ -305,7 +301,7 @@ void MhiClimate::control(const climate::ClimateCall& call) {
 
     if (call.get_mode().has_value()) {
         this->mode = *call.get_mode();
-        
+
         this->power_ = power_on;
         switch (this->mode) {
         case climate::CLIMATE_MODE_OFF:
@@ -374,25 +370,23 @@ void MhiClimate::control(const climate::ClimateCall& call) {
             break;
         default:
         case climate::CLIMATE_SWING_BOTH:
-            // vanes_ = vanes_swing;
             vanesLR_ = vanesLR_swing;
             vanes_ = vanes_swing;
             break;
         }
-        this->platform_->set_vanesLR(vanesLR_); // Set vanesLR to swing
-        this->platform_->set_vanes(vanes_); // Set vanes to swing
+        this->platform_->set_vanesLR(vanesLR_);
+        this->platform_->set_vanes(vanes_);
     }
 
     this->publish_state();
 }
-
 
 /// Return the traits of this controller.
 #if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 11, 0)
 climate::ClimateTraits MhiClimate::traits() {
     auto traits = climate::ClimateTraits();
     traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
-    traits.set_supported_modes({ climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_COOL, climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_DRY,climate::CLIMATE_MODE_FAN_ONLY });
+    traits.set_supported_modes({ climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_COOL, climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_DRY, climate::CLIMATE_MODE_FAN_ONLY });
     traits.set_visual_min_temperature(this->minimum_temperature_);
     traits.set_visual_max_temperature(this->maximum_temperature_);
     traits.set_visual_temperature_step(this->temperature_step_);
@@ -415,6 +409,5 @@ climate::ClimateTraits MhiClimate::traits() {
 }
 #endif
 
-
-} //namespace mhi
-} //namespace esphome
+} // namespace mhi
+} // namespace esphome

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -42,6 +42,7 @@ void MhiClimate::clear_all_pending_() {
 void MhiClimate::setup() {
     this->power_ = power_off;
     this->current_temperature = NAN;
+    this->startup_power_synced_ = false;
 
     float restored_target_temperature = NAN;
     auto restore = this->restore_state_();
@@ -80,6 +81,8 @@ void MhiClimate::update_status(ACStatus status, int value) {
 
     switch (status) {
     case status_power: {
+        this->startup_power_synced_ = true;
+
         const ACPower new_power = (value == power_on) ? power_on : power_off;
 
         if (this->pending_power_valid_ && this->pending_window_active_() &&
@@ -117,15 +120,24 @@ void MhiClimate::update_status(ACStatus status, int value) {
         [[fallthrough]];
     case opdata_mode:
     case erropdata_mode: {
+        if (!this->startup_power_synced_) {
+            ESP_LOGV(TAG, "Ignoring mode status %d before initial power sync", value);
+            break;
+        }
+
+        if (this->power_ != power_on) {
+            if (this->mode != climate::CLIMATE_MODE_OFF) {
+                this->mode = climate::CLIMATE_MODE_OFF;
+                dirty = true;
+            }
+            break;
+        }
+
         auto new_mode = this->mode;
 
         switch (value) {
         case mode_auto:
-            if (status != erropdata_mode && this->power_ > 0) {
-                new_mode = climate::CLIMATE_MODE_HEAT_COOL;
-            } else {
-                new_mode = climate::CLIMATE_MODE_OFF;
-            }
+            new_mode = climate::CLIMATE_MODE_HEAT_COOL;
             break;
         case mode_dry:
             new_mode = climate::CLIMATE_MODE_DRY;
@@ -162,6 +174,11 @@ void MhiClimate::update_status(ACStatus status, int value) {
     }
 
     case status_fan: {
+        if (!this->startup_power_synced_) {
+            ESP_LOGV(TAG, "Ignoring fan status %d before initial power sync", value);
+            break;
+        }
+
         auto new_fan_mode = this->fan_mode;
 
         switch (value) {
@@ -202,6 +219,11 @@ void MhiClimate::update_status(ACStatus status, int value) {
     }
 
     case status_vanes: {
+        if (!this->startup_power_synced_) {
+            ESP_LOGV(TAG, "Ignoring vertical vanes status %d before initial power sync", value);
+            break;
+        }
+
         auto new_swing_mode = this->swing_mode;
         int new_vanes_pos_old_state = this->vanes_pos_old_state_;
 
@@ -261,6 +283,11 @@ void MhiClimate::update_status(ACStatus status, int value) {
     }
 
     case status_vanesLR: {
+        if (!this->startup_power_synced_) {
+            ESP_LOGV(TAG, "Ignoring horizontal vanes status %d before initial power sync", value);
+            break;
+        }
+
         auto new_swing_mode = this->swing_mode;
         int new_vanesLR_pos_old_state = this->vanesLR_pos_old_state_;
 
@@ -334,6 +361,11 @@ void MhiClimate::update_status(ACStatus status, int value) {
     }
 
     case status_tsetpoint: {
+        if (!this->startup_power_synced_) {
+            ESP_LOGV(TAG, "Ignoring tsetpoint %.1f before initial power sync", (value & 0x7f) / 2.0f);
+            break;
+        }
+
         float ac_setpoint = (value & 0x7f) / 2.0f;
 
         if (this->temperature_offset_ != 0.0f &&

--- a/components/MhiAcCtrl/climate/mhi_climate.h
+++ b/components/MhiAcCtrl/climate/mhi_climate.h
@@ -62,6 +62,8 @@ private:
     bool pending_swing_valid_{false};
     climate::ClimateSwingMode pending_swing_mode_{climate::CLIMATE_SWING_OFF};
 
+    bool startup_power_synced_{false};
+
     bool pending_window_active_() const;
     void start_pending_window_();
     void clear_expired_pending_();

--- a/components/MhiAcCtrl/climate/mhi_climate.h
+++ b/components/MhiAcCtrl/climate/mhi_climate.h
@@ -11,14 +11,13 @@ using namespace esphome::climate;
 namespace esphome {
 namespace mhi {
 
-class MhiClimate : 
-    public climate::Climate, 
-    public Component, 
-    public Parented<MhiPlatform>, 
+class MhiClimate :
+    public climate::Climate,
+    public Component,
+    public Parented<MhiPlatform>,
     protected MhiStatusListener {
 
 protected:
-
     void setup() override;
     void dump_config() override;
     void control(const climate::ClimateCall& call) override;
@@ -26,8 +25,10 @@ protected:
     void update_status(ACStatus status, int value) override;
 
 private:
+    static constexpr uint32_t kCommandSettleWindowMs = 1500U;
+
     bool temperature_offset_enabled_{false};
-    float temperature_offset_{0.0};
+    float temperature_offset_{0.0f};
     float minimum_temperature_{18.0f};
     float maximum_temperature_{30.0f};
     float temperature_step_{0.5f};
@@ -39,18 +40,40 @@ private:
     ACVanes vanes_;
     ACVanesLR vanesLR_;
     int vanesLR_pos_old_state_;
-    int vanesLR_pos_state_;
+    int vanesLR_pos_state_{0};
     int vanes_pos_old_state_;
-    int vanes_pos_state_;
+    int vanes_pos_state_{0};
     MhiPlatform* platform_;
 
+    uint32_t pending_until_ms_{0};
+
+    bool pending_power_valid_{false};
+    ACPower pending_power_{power_off};
+
+    bool pending_mode_valid_{false};
+    climate::ClimateMode pending_mode_{climate::CLIMATE_MODE_OFF};
+
+    bool pending_target_temperature_valid_{false};
+    float pending_target_temperature_{0.0f};
+
+    bool pending_fan_valid_{false};
+    climate::ClimateFanMode pending_fan_mode_{climate::CLIMATE_FAN_AUTO};
+
+    bool pending_swing_valid_{false};
+    climate::ClimateSwingMode pending_swing_mode_{climate::CLIMATE_SWING_OFF};
+
+    bool pending_window_active_() const;
+    void start_pending_window_();
+    void clear_expired_pending_();
+    void clear_all_pending_();
+
 public:
-    void set_temperature_offset_enabled(bool enabled) { 
-        this->temperature_offset_enabled_ = enabled; 
+    void set_temperature_offset_enabled(bool enabled) {
+        this->temperature_offset_enabled_ = enabled;
     }
 
-    void set_minimum_temperature(float temp) { 
-        this->minimum_temperature_ = temp; 
+    void set_minimum_temperature(float temp) {
+        this->minimum_temperature_ = temp;
     }
 };
 

--- a/components/MhiAcCtrl/mhi_platform.cpp
+++ b/components/MhiAcCtrl/mhi_platform.cpp
@@ -70,11 +70,6 @@ void MhiPlatform::set_external_room_temperature_sensor(
 }
 
 void MhiPlatform::loop() {
-  if (this->external_temperature_sensor_ != nullptr) {
-    this->transfer_room_temperature(this->external_temperature_sensor_->state);
-    this->room_temp_api_active_ = false;
-  }
-
   if (this->room_temp_api_active_ &&
       mhi_now_ms() - this->room_temp_api_timeout_start_ >=
           this->room_temp_api_timeout_ * 1000U) {

--- a/components/MhiAcCtrl/mhi_platform.cpp
+++ b/components/MhiAcCtrl/mhi_platform.cpp
@@ -103,7 +103,7 @@ void MhiPlatform::dump_config() {
 }
 
 void MhiPlatform::cbiStatusFunction(ACStatus status, int value) {
-  ESP_LOGD(TAG, "received status=%i value=%i", status, value);
+  ESP_LOGV(TAG, "received status=%i value=%i", status, value);
 
   for (MhiStatusListener *listener : this->listeners_) {
     listener->update_status(status, value);
@@ -127,7 +127,7 @@ float MhiPlatform::get_room_temp_offset() {
 void MhiPlatform::transfer_room_temperature(float value) {
   if (std::isnan(value)) {
     if (!std::isnan(this->last_room_temperature_)) {
-      ESP_LOGD(TAG, "set room_temp_api: value is NaN, using internal sensor");
+      ESP_LOGV(TAG, "set room_temp_api: value is NaN, using internal sensor");
       this->mhi_ac_ctrl_core_.set_troom(0xff);
       this->last_room_temperature_ = NAN;
     }
@@ -146,7 +146,7 @@ void MhiPlatform::transfer_room_temperature(float value) {
     const uint8_t tmp = static_cast<uint8_t>(value * 4 + 61);
     this->mhi_ac_ctrl_core_.set_troom(tmp);
     this->last_room_temperature_ = value;
-    ESP_LOGD(TAG, "set room_temp_api: %f %i", value, tmp);
+    ESP_LOGV(TAG, "set room_temp_api: %f %i", value, tmp);
   }
 }
 
@@ -171,7 +171,7 @@ void MhiPlatform::set_tsetpoint(float value) {
     const float last = this->last_room_temperature_;
     this->last_room_temperature_ = NAN;
     this->transfer_room_temperature(last);
-    ESP_LOGD(TAG, "resending external troom: %f", last);
+    ESP_LOGV(TAG, "resending external troom: %f", last);
   }
 }
 


### PR DESCRIPTION
This PR improves runtime efficiency and state consistency for the ESPHome MHI climate component. It reduces redundant publish_state() calls, removes duplicate hot-path logging, and adds a pending-command reconciliation window to stop stale inbound frames from overriding rapid local changes. Startup behaviour was hardened so the entity no longer trusts restored live state as truth on boot, preventing false mode reporting when the AC is actually off.