### PR TITLE
Fix opdata sensors remaining `Unknown` after startup

### DIFF
--- a/components/MhiAcCtrl/mhi_platform.cpp
+++ b/components/MhiAcCtrl/mhi_platform.cpp
@@ -46,6 +46,8 @@ void MhiPlatform::setup() {
   this->mhi_ac_ctrl_core_.init();
   this->mhi_ac_ctrl_core_.set_frame_size(static_cast<uint8_t>(this->frame_size_));
 
+  this->mhi_ac_ctrl_core_.set_enabled_opdata_mask(this->opdata_mask_);
+
   if (this->external_temperature_sensor_ != nullptr) {
     this->external_temperature_sensor_->add_on_state_callback(
         [this](float state) { this->transfer_room_temperature(state); });


### PR DESCRIPTION
### Problem
Recent optimisation to only request configured opdata introduced a regression where many sensors remained `Unknown`.

### Root cause
`MHI_AC_Ctrl_Core::init()` resets the runtime state, including the opdata request mask.  
This overwrote the mask built from configured sensors, leaving only the default `MODE` request active.

### Fix
Re-apply the configured opdata mask after `init()` in `mhi_platform.cpp`.

### Result
- Configured sensors are now correctly requested after boot
- Previously broken sensors (fan speed, compressor frequency, power, etc.) populate as expected
- Optimisation remains intact (only configured opdata is requested)

### Scope
- Minimal change
- No functional changes outside restoring expected behaviour

Thanks @locussss for bringing this to my attention :)