### PR TITLE
External temp inclusion

### DIFF
--- a/components/MhiAcCtrl/automation.h
+++ b/components/MhiAcCtrl/automation.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "esphome/core/automation.h"
+#include "esphome/core/version.h"
+#include "mhi_ac_ctrl.h"
+
+namespace esphome {
+namespace mhi_ac_ctrl {
+
+template <typename... Ts>
+class SetVerticalVanesAction : public Action<Ts...> {
+ public:
+  explicit SetVerticalVanesAction(MhiAcCtrl* parent) : parent_(parent) {}
+
+  TEMPLATABLE_VALUE(int, position);
+
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 11, 0)
+  void play(const Ts&... x) override
+#else
+  void play(Ts... x) override
+#endif
+  {
+    if (this->parent_ == nullptr) {
+      return;
+    }
+
+    const int position = this->position_.value(x...);
+    if (position < 1 || position > 5) {
+      return;
+    }
+
+    auto& command = this->parent_->state().command();
+    command.vertical_vane_set = true;
+    command.vertical_vane = static_cast<uint8_t>(position);
+  }
+
+ protected:
+  MhiAcCtrl* parent_;
+};
+
+template <typename... Ts>
+class SetHorizontalVanesAction : public Action<Ts...> {
+ public:
+  explicit SetHorizontalVanesAction(MhiAcCtrl* parent) : parent_(parent) {}
+
+  TEMPLATABLE_VALUE(int, position);
+
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 11, 0)
+  void play(const Ts&... x) override
+#else
+  void play(Ts... x) override
+#endif
+  {
+    if (this->parent_ == nullptr) {
+      return;
+    }
+
+    const int position = this->position_.value(x...);
+    if (position >= 1 && position <= 8) {
+      this->parent_->request_horizontal_vane_command(static_cast<uint8_t>(position));
+    }
+  }
+
+ protected:
+  MhiAcCtrl* parent_;
+};
+
+template <typename... Ts>
+class SetExternalRoomTemperatureAction : public Action<Ts...> {
+ public:
+  explicit SetExternalRoomTemperatureAction(MhiAcCtrl* parent) : parent_(parent) {}
+
+  TEMPLATABLE_VALUE(float, temperature);
+
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 11, 0)
+  void play(const Ts&... x) override
+#else
+  void play(Ts... x) override
+#endif
+  {
+    if (this->parent_ != nullptr) {
+      this->parent_->set_external_room_temperature(this->temperature_.value(x...));
+    }
+  }
+
+ protected:
+  MhiAcCtrl* parent_;
+};
+
+}  // namespace mhi_ac_ctrl
+}  // namespace esphome

--- a/components/MhiAcCtrl/mhi_ac_ctrl.cpp
+++ b/components/MhiAcCtrl/mhi_ac_ctrl.cpp
@@ -3,6 +3,8 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
+#include <cmath>
+
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
@@ -25,19 +27,14 @@ bool in_range(float value, float min_value, float max_value) {
 }  // namespace
 
 void MhiAcCtrl::set_external_room_temperature(float value) {
-  if (std::isnan(value)) {
-    this->room_temp_api_active_ = false;
-    this->clear_external_room_temperature_();
-    return;
-  }
-
-  this->room_temp_api_active_ = true;
-  this->room_temp_api_timeout_start_ms_ = millis();
-  this->apply_external_room_temperature_(value);
+  this->apply_external_room_temperature_(value, true);
 }
 
-void MhiAcCtrl::apply_external_room_temperature_(float value) {
+void MhiAcCtrl::apply_external_room_temperature_(float value, bool api_value) {
   if (std::isnan(value)) {
+    if (api_value) {
+      this->room_temp_api_active_ = false;
+    }
     this->clear_external_room_temperature_();
     return;
   }
@@ -47,31 +44,38 @@ void MhiAcCtrl::apply_external_room_temperature_(float value) {
     return;
   }
 
-  if (!std::isnan(this->last_external_room_temperature_c_) &&
-      std::fabs(value - this->last_external_room_temperature_c_) < 0.01f) {
-    return;
+  if (api_value) {
+    this->room_temp_api_active_ = true;
+    this->room_temp_api_timeout_start_ms_ = millis();
+  } else {
+    // A configured sensor owns the value and does not use the API timeout.
+    this->room_temp_api_active_ = false;
   }
 
-  auto& command = this->state_.command();
-  command.room_temp_override_raw = static_cast<uint8_t>((value * 4.0f) + 61.0f);
-  command.room_temp_override_set = true;
-  this->last_external_room_temperature_c_ = value;
+  const uint8_t raw = static_cast<uint8_t>((value * 4.0f) + 61.0f);
+  const bool changed = std::isnan(this->last_external_room_temperature_c_) ||
+                       std::fabs(value - this->last_external_room_temperature_c_) >= 0.01f ||
+                       this->tx_runtime_.room_temp_override_raw != raw;
 
-  ESP_LOGD(DIAG_TAG, "external room temperature staged: %.2fC raw=0x%02x", value,
-           static_cast<unsigned int>(command.room_temp_override_raw));
+  this->last_external_room_temperature_c_ = value;
+  this->tx_runtime_.room_temp_override_raw = raw;
+
+  if (changed) {
+    ESP_LOGI(DIAG_TAG, "external room temperature active: %.2fC raw=0x%02x source=%s", value,
+             static_cast<unsigned int>(raw), api_value ? "API" : "sensor");
+  }
 }
 
 void MhiAcCtrl::clear_external_room_temperature_() {
-  if (std::isnan(this->last_external_room_temperature_c_) && this->tx_runtime_.room_temp_override_raw == 0xFFU) {
-    return;
-  }
+  const bool changed =
+      this->tx_runtime_.room_temp_override_raw != 0xFFU || !std::isnan(this->last_external_room_temperature_c_);
 
-  auto& command = this->state_.command();
-  command.room_temp_override_raw = 0xFFU;
-  command.room_temp_override_set = true;
+  this->tx_runtime_.room_temp_override_raw = 0xFFU;
   this->last_external_room_temperature_c_ = NAN;
 
-  ESP_LOGD(DIAG_TAG, "external room temperature cleared; using indoor-unit sensor");
+  if (changed) {
+    ESP_LOGI(DIAG_TAG, "external room temperature cleared; using indoor-unit sensor");
+  }
 }
 
 void MhiAcCtrl::check_external_room_temperature_timeout_() {
@@ -81,14 +85,13 @@ void MhiAcCtrl::check_external_room_temperature_timeout_() {
 
   const uint32_t timeout_ms = static_cast<uint32_t>(this->room_temp_api_timeout_s_) * 1000U;
   const uint32_t now = millis();
-
   if ((now - this->room_temp_api_timeout_start_ms_) < timeout_ms) {
     return;
   }
 
   this->room_temp_api_active_ = false;
   this->clear_external_room_temperature_();
-  ESP_LOGD(DIAG_TAG, "external room temperature timed out after %ds", this->room_temp_api_timeout_s_);
+  ESP_LOGI(DIAG_TAG, "external room temperature API value timed out after %ds", this->room_temp_api_timeout_s_);
 }
 
 bool MhiAcCtrl::request_horizontal_vane_command(uint8_t horizontal_vane) {
@@ -189,6 +192,7 @@ void MhiAcCtrl::setup() {
   this->room_temp_api_active_ = false;
   this->room_temp_api_timeout_start_ms_ = 0U;
   this->last_external_room_temperature_c_ = NAN;
+  this->tx_runtime_.room_temp_override_raw = 0xFFU;
   this->rx_worker_running_ = false;
   this->rx_worker_stop_requested_ = false;
   this->rx_worker_started_ = false;
@@ -233,11 +237,9 @@ void MhiAcCtrl::setup() {
   this->transport_.setup();
 
   if (this->external_room_temperature_sensor_ != nullptr) {
-    this->external_room_temperature_sensor_->add_on_state_callback([this](float state) {
-      this->room_temp_api_active_ = false;
-      this->apply_external_room_temperature_(state);
-    });
-    this->apply_external_room_temperature_(this->external_room_temperature_sensor_->state);
+    this->external_room_temperature_sensor_->add_on_state_callback(
+        [this](float state) { this->apply_external_room_temperature_(state, false); });
+    this->apply_external_room_temperature_(this->external_room_temperature_sensor_->state, false);
   }
 
   this->start_rx_worker_();
@@ -291,8 +293,10 @@ void MhiAcCtrl::dump_config() {
   ESP_LOGCONFIG(TAG, "MHI AC Ctrl rewrite skeleton:");
   ESP_LOGCONFIG(TAG, "  Frame size: %d", this->frame_size_);
   ESP_LOGCONFIG(TAG, "  Room temp timeout: %ds", this->room_temp_api_timeout_s_);
-  ESP_LOGCONFIG(TAG, "  External room temperature sensor: %s",
+  ESP_LOGCONFIG(TAG, "  External temperature sensor: %s",
                 this->external_room_temperature_sensor_ != nullptr ? "YES" : "NO");
+  ESP_LOGCONFIG(TAG, "  External room temperature raw: 0x%02x",
+                static_cast<unsigned int>(this->tx_runtime_.room_temp_override_raw));
   ESP_LOGCONFIG(TAG, "  Pins: SCK=%d MOSI=%d MISO=%d", this->pins_.sck, this->pins_.mosi, this->pins_.miso);
   ESP_LOGCONFIG(TAG, "  RX driver configured: %s", this->rx_driver_.c_str());
   ESP_LOGCONFIG(TAG, "  TX driver configured: %s", this->tx_driver_.c_str());

--- a/components/MhiAcCtrl/mhi_ac_ctrl.cpp
+++ b/components/MhiAcCtrl/mhi_ac_ctrl.cpp
@@ -24,6 +24,73 @@ bool in_range(float value, float min_value, float max_value) {
 
 }  // namespace
 
+void MhiAcCtrl::set_external_room_temperature(float value) {
+  if (std::isnan(value)) {
+    this->room_temp_api_active_ = false;
+    this->clear_external_room_temperature_();
+    return;
+  }
+
+  this->room_temp_api_active_ = true;
+  this->room_temp_api_timeout_start_ms_ = millis();
+  this->apply_external_room_temperature_(value);
+}
+
+void MhiAcCtrl::apply_external_room_temperature_(float value) {
+  if (std::isnan(value)) {
+    this->clear_external_room_temperature_();
+    return;
+  }
+
+  if (value <= -10.0f || value >= 48.0f) {
+    ESP_LOGW(DIAG_TAG, "external room temperature ignored: %.2fC is outside the supported range", value);
+    return;
+  }
+
+  if (!std::isnan(this->last_external_room_temperature_c_) &&
+      std::fabs(value - this->last_external_room_temperature_c_) < 0.01f) {
+    return;
+  }
+
+  auto& command = this->state_.command();
+  command.room_temp_override_raw = static_cast<uint8_t>((value * 4.0f) + 61.0f);
+  command.room_temp_override_set = true;
+  this->last_external_room_temperature_c_ = value;
+
+  ESP_LOGD(DIAG_TAG, "external room temperature staged: %.2fC raw=0x%02x", value,
+           static_cast<unsigned int>(command.room_temp_override_raw));
+}
+
+void MhiAcCtrl::clear_external_room_temperature_() {
+  if (std::isnan(this->last_external_room_temperature_c_) && this->tx_runtime_.room_temp_override_raw == 0xFFU) {
+    return;
+  }
+
+  auto& command = this->state_.command();
+  command.room_temp_override_raw = 0xFFU;
+  command.room_temp_override_set = true;
+  this->last_external_room_temperature_c_ = NAN;
+
+  ESP_LOGD(DIAG_TAG, "external room temperature cleared; using indoor-unit sensor");
+}
+
+void MhiAcCtrl::check_external_room_temperature_timeout_() {
+  if (!this->room_temp_api_active_ || this->room_temp_api_timeout_s_ <= 0) {
+    return;
+  }
+
+  const uint32_t timeout_ms = static_cast<uint32_t>(this->room_temp_api_timeout_s_) * 1000U;
+  const uint32_t now = millis();
+
+  if ((now - this->room_temp_api_timeout_start_ms_) < timeout_ms) {
+    return;
+  }
+
+  this->room_temp_api_active_ = false;
+  this->clear_external_room_temperature_();
+  ESP_LOGD(DIAG_TAG, "external room temperature timed out after %ds", this->room_temp_api_timeout_s_);
+}
+
 bool MhiAcCtrl::request_horizontal_vane_command(uint8_t horizontal_vane) {
   if (horizontal_vane < 1U || horizontal_vane > 8U) {
     ESP_LOGW(DIAG_TAG, "command: unsupported horizontal vane request value=%u",
@@ -119,6 +186,9 @@ void MhiAcCtrl::setup() {
   this->tx_background_attempts_ = 0U;
   this->tx_background_failures_ = 0U;
   this->tx_command_priority_attempts_ = 0U;
+  this->room_temp_api_active_ = false;
+  this->room_temp_api_timeout_start_ms_ = 0U;
+  this->last_external_room_temperature_c_ = NAN;
   this->rx_worker_running_ = false;
   this->rx_worker_stop_requested_ = false;
   this->rx_worker_started_ = false;
@@ -162,6 +232,14 @@ void MhiAcCtrl::setup() {
 
   this->transport_.setup();
 
+  if (this->external_room_temperature_sensor_ != nullptr) {
+    this->external_room_temperature_sensor_->add_on_state_callback([this](float state) {
+      this->room_temp_api_active_ = false;
+      this->apply_external_room_temperature_(state);
+    });
+    this->apply_external_room_temperature_(this->external_room_temperature_sensor_->state);
+  }
+
   this->start_rx_worker_();
   this->start_tx_worker_();
 
@@ -181,6 +259,7 @@ void MhiAcCtrl::loop() {
   uint32_t rx_read_sync_us = 0U;
 
   section_start_us = micros();
+  this->check_external_room_temperature_timeout_();
   this->build_and_stage_tx_frame_();
   tx_stage_us = elapsed_us_(section_start_us);
 
@@ -212,6 +291,8 @@ void MhiAcCtrl::dump_config() {
   ESP_LOGCONFIG(TAG, "MHI AC Ctrl rewrite skeleton:");
   ESP_LOGCONFIG(TAG, "  Frame size: %d", this->frame_size_);
   ESP_LOGCONFIG(TAG, "  Room temp timeout: %ds", this->room_temp_api_timeout_s_);
+  ESP_LOGCONFIG(TAG, "  External room temperature sensor: %s",
+                this->external_room_temperature_sensor_ != nullptr ? "YES" : "NO");
   ESP_LOGCONFIG(TAG, "  Pins: SCK=%d MOSI=%d MISO=%d", this->pins_.sck, this->pins_.mosi, this->pins_.miso);
   ESP_LOGCONFIG(TAG, "  RX driver configured: %s", this->rx_driver_.c_str());
   ESP_LOGCONFIG(TAG, "  TX driver configured: %s", this->tx_driver_.c_str());

--- a/components/MhiAcCtrl/mhi_ac_ctrl.h
+++ b/components/MhiAcCtrl/mhi_ac_ctrl.h
@@ -3,6 +3,7 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/portmacro.h>
 
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -144,6 +145,8 @@ class MhiAcCtrl : public Component {
   void set_external_room_temperature_sensor(sensor::Sensor* sensor) {
     this->external_room_temperature_sensor_ = sensor;
   }
+
+  void set_external_room_temperature(float value);
 
   // Compatibility aliases for old config names.
   void set_vanes(int position) {
@@ -376,12 +379,18 @@ class MhiAcCtrl : public Component {
   bool background_tx_due_(uint32_t now_ms) const;
   bool command_confirmation_pending_() const;
   bool background_tx_allowed_(uint32_t now_ms);
+  void apply_external_room_temperature_(float value);
+  void clear_external_room_temperature_();
+  void check_external_room_temperature_timeout_();
 
   static uint32_t elapsed_us_(uint32_t start_us);
   static uint8_t detect_chip_core_count_();
 
   int frame_size_{20};
   int room_temp_api_timeout_s_{60};
+  bool room_temp_api_active_{false};
+  uint32_t room_temp_api_timeout_start_ms_{0U};
+  float last_external_room_temperature_c_{NAN};
 
   int initial_vertical_vanes_position_{0};
   int initial_horizontal_vanes_position_{0};

--- a/components/MhiAcCtrl/mhi_ac_ctrl.h
+++ b/components/MhiAcCtrl/mhi_ac_ctrl.h
@@ -146,6 +146,7 @@ class MhiAcCtrl : public Component {
     this->external_room_temperature_sensor_ = sensor;
   }
 
+  // Used by the compatibility automation action/API service.
   void set_external_room_temperature(float value);
 
   // Compatibility aliases for old config names.
@@ -379,7 +380,7 @@ class MhiAcCtrl : public Component {
   bool background_tx_due_(uint32_t now_ms) const;
   bool command_confirmation_pending_() const;
   bool background_tx_allowed_(uint32_t now_ms);
-  void apply_external_room_temperature_(float value);
+  void apply_external_room_temperature_(float value, bool api_value);
   void clear_external_room_temperature_();
   void check_external_room_temperature_timeout_();
 
@@ -388,9 +389,6 @@ class MhiAcCtrl : public Component {
 
   int frame_size_{20};
   int room_temp_api_timeout_s_{60};
-  bool room_temp_api_active_{false};
-  uint32_t room_temp_api_timeout_start_ms_{0U};
-  float last_external_room_temperature_c_{NAN};
 
   int initial_vertical_vanes_position_{0};
   int initial_horizontal_vanes_position_{0};
@@ -401,6 +399,9 @@ class MhiAcCtrl : public Component {
   std::string tx_driver_{"fast_gpio"};
 
   sensor::Sensor* external_room_temperature_sensor_{nullptr};
+  float last_external_room_temperature_c_{NAN};
+  bool room_temp_api_active_{false};
+  uint32_t room_temp_api_timeout_start_ms_{0U};
 
   uint32_t opdata_mask_{kMhiDefaultOpdataMask};
 

--- a/components/MhiAcCtrl/mhi_tx_builder.cpp
+++ b/components/MhiAcCtrl/mhi_tx_builder.cpp
@@ -232,10 +232,12 @@ void MhiTxBuilder::apply_commands(MhiFrameBuffer& out, MhiCommandState& command,
   }
 
   if (command.room_temp_override_set) {
-    out.data[DB3] = command.room_temp_override_raw;
+    runtime.room_temp_override_raw = command.room_temp_override_raw;
     command.room_temp_override_set = false;
     result.encoded_command_mask |= MHI_COMMAND_ROOM_TEMP_OVERRIDE;
   }
+
+  out.data[DB3] = runtime.room_temp_override_raw;
 
   if (out.len == kMhiFrame33Bytes) {
     out.data[DB16] = 0x00U;

--- a/components/MhiAcCtrl/mhi_tx_builder.cpp
+++ b/components/MhiAcCtrl/mhi_tx_builder.cpp
@@ -231,12 +231,13 @@ void MhiTxBuilder::apply_commands(MhiFrameBuffer& out, MhiCommandState& command,
     }
   }
 
+  // Room temperature is persistent transport state, not a one-shot confirmed command.
+  // Retain compatibility with callers that still stage the legacy command field,
+  // then place the active value in every outgoing frame.
   if (command.room_temp_override_set) {
     runtime.room_temp_override_raw = command.room_temp_override_raw;
     command.room_temp_override_set = false;
-    result.encoded_command_mask |= MHI_COMMAND_ROOM_TEMP_OVERRIDE;
   }
-
   out.data[DB3] = runtime.room_temp_override_raw;
 
   if (out.len == kMhiFrame33Bytes) {

--- a/components/MhiAcCtrl/mhi_tx_builder.h
+++ b/components/MhiAcCtrl/mhi_tx_builder.h
@@ -36,6 +36,7 @@ constexpr uint32_t kMhiDefaultOpdataMask = MHI_OPDATA_REQ_MODE;
 
 struct MhiTxRuntime {
   uint8_t opdata_index{0};
+  uint8_t room_temp_override_raw{0xFF};
   uint8_t error_opdata_count{0};
   bool double_frame{false};
   uint32_t frame_counter{1};

--- a/components/MhiAcCtrl/mhi_tx_builder.h
+++ b/components/MhiAcCtrl/mhi_tx_builder.h
@@ -36,6 +36,7 @@ constexpr uint32_t kMhiDefaultOpdataMask = MHI_OPDATA_REQ_MODE;
 
 struct MhiTxRuntime {
   uint8_t opdata_index{0};
+  // Persistent DB3 room-temperature override. 0xFF selects the indoor-unit sensor.
   uint8_t room_temp_override_raw{0xFF};
   uint8_t error_opdata_count{0};
   bool double_frame{false};

--- a/tests/components/MhiAcCtrl/test.esp32-s3-idf.yaml
+++ b/tests/components/MhiAcCtrl/test.esp32-s3-idf.yaml
@@ -29,6 +29,7 @@ MhiAcCtrl:
   initial_vertical_vanes_position: 5
   initial_horizontal_vanes_position: 8
   room_temp_timeout: 60
+  external_temperature_sensor: external_room_temperature
 
 climate:
   - platform: MhiAcCtrl
@@ -41,6 +42,11 @@ climate:
 
 
 sensor:
+  - platform: template
+    id: external_room_temperature
+    name: Compile Test External Room Temperature
+    update_interval: never
+
   - platform: MhiAcCtrl
     mhi_ac_ctrl_id: mhi_ac
     room_temperature:
@@ -135,14 +141,3 @@ switch:
     mhi_ac_ctrl_id: mhi_ac
     vanes_3d_auto:
       name: MHI 3D Auto
-
-
-api:
-  services:
-    - service: set_external_room_temperature
-      variables:
-        temperature_value: float
-      then:
-        - climate.mhi.set_external_room_temperature:
-            mhi_ac_ctrl_id: mhi_ac
-            temperature: !lambda "return temperature_value;"

--- a/tests/components/MhiAcCtrl/test.esp32-s3-idf.yaml
+++ b/tests/components/MhiAcCtrl/test.esp32-s3-idf.yaml
@@ -135,3 +135,14 @@ switch:
     mhi_ac_ctrl_id: mhi_ac
     vanes_3d_auto:
       name: MHI 3D Auto
+
+
+api:
+  services:
+    - service: set_external_room_temperature
+      variables:
+        temperature_value: float
+      then:
+        - climate.mhi.set_external_room_temperature:
+            mhi_ac_ctrl_id: mhi_ac
+            temperature: !lambda "return temperature_value;"

--- a/tests/unit/mhi_test_common.h
+++ b/tests/unit/mhi_test_common.h
@@ -240,8 +240,6 @@ void tx_builder_drops_33_byte_only_commands_in_20_byte_mode();
 void tx_builder_applies_3d_auto_in_33_byte_frame();
 void tx_builder_reports_horizontal_vane_intent_in_33_byte_frame();
 void tx_builder_preserves_horizontal_context_for_3d_auto_command();
-void tx_builder_persists_external_room_temperature_override();
-void tx_builder_clears_external_room_temperature_override();
 
 void command_confirmation_confirms_power_mode_and_vertical_vane();
 void command_confirmation_keeps_partial_pending_until_later_status();
@@ -271,5 +269,8 @@ void fixture_bad_checksum_rejects();
 void fixture_garbage_then_valid_frame_resyncs();
 void fixture_opdata_outdoor_temp_decodes();
 void fixture_opdata_current_decodes();
+
+void tx_builder_persists_external_room_temperature_override();
+void tx_builder_clears_external_room_temperature_override();
 
 }  // namespace mhi_unit_tests

--- a/tests/unit/mhi_test_common.h
+++ b/tests/unit/mhi_test_common.h
@@ -240,6 +240,8 @@ void tx_builder_drops_33_byte_only_commands_in_20_byte_mode();
 void tx_builder_applies_3d_auto_in_33_byte_frame();
 void tx_builder_reports_horizontal_vane_intent_in_33_byte_frame();
 void tx_builder_preserves_horizontal_context_for_3d_auto_command();
+void tx_builder_persists_external_room_temperature_override();
+void tx_builder_clears_external_room_temperature_override();
 
 void command_confirmation_confirms_power_mode_and_vertical_vane();
 void command_confirmation_keeps_partial_pending_until_later_status();

--- a/tests/unit/mhi_unit_test_main.cpp
+++ b/tests/unit/mhi_unit_test_main.cpp
@@ -62,8 +62,6 @@ int main() {
   tx_builder_applies_3d_auto_in_33_byte_frame();
   tx_builder_reports_horizontal_vane_intent_in_33_byte_frame();
   tx_builder_preserves_horizontal_context_for_3d_auto_command();
-  tx_builder_persists_external_room_temperature_override();
-  tx_builder_clears_external_room_temperature_override();
 
   command_confirmation_confirms_power_mode_and_vertical_vane();
   command_confirmation_keeps_partial_pending_until_later_status();
@@ -92,6 +90,9 @@ int main() {
   fixture_garbage_then_valid_frame_resyncs();
   fixture_opdata_outdoor_temp_decodes();
   fixture_opdata_current_decodes();
+
+  tx_builder_persists_external_room_temperature_override();
+  tx_builder_clears_external_room_temperature_override();
 
   std::cout << "MHI protocol unit tests passed\n";
   return 0;

--- a/tests/unit/mhi_unit_test_main.cpp
+++ b/tests/unit/mhi_unit_test_main.cpp
@@ -62,6 +62,8 @@ int main() {
   tx_builder_applies_3d_auto_in_33_byte_frame();
   tx_builder_reports_horizontal_vane_intent_in_33_byte_frame();
   tx_builder_preserves_horizontal_context_for_3d_auto_command();
+  tx_builder_persists_external_room_temperature_override();
+  tx_builder_clears_external_room_temperature_override();
 
   command_confirmation_confirms_power_mode_and_vertical_vane();
   command_confirmation_keeps_partial_pending_until_later_status();

--- a/tests/unit/test_tx_builder.cpp
+++ b/tests/unit/test_tx_builder.cpp
@@ -233,43 +233,37 @@ void tx_builder_preserves_horizontal_context_for_3d_auto_command() {
   EXPECT_FALSE(command.has_pending_command());
 }
 
-
-
 void tx_builder_persists_external_room_temperature_override() {
   MhiCommandState command{};
-  command.room_temp_override_set = true;
-  command.room_temp_override_raw = 0x9DU;  // 24.0C: (24 * 4) + 61.
-
   MhiTxRuntime runtime{};
   MhiTxBuildConfig config{};
-  MhiFrameBuffer out{};
-  MhiTxBuildResult result{};
+  MhiFrameBuffer first{};
+  MhiFrameBuffer second{};
 
-  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, out, result));
-  EXPECT_EQ(out.data[DB3], 0x9DU);
-  EXPECT_EQ(result.encoded_command_mask, static_cast<uint32_t>(MHI_COMMAND_ROOM_TEMP_OVERRIDE));
-  EXPECT_FALSE(command.room_temp_override_set);
+  config.frame_size = kMhiFrame20Bytes;
+  runtime.room_temp_override_raw = 0x89U;
 
-  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, out, result));
-  EXPECT_EQ(out.data[DB3], 0x9DU);
-  EXPECT_EQ(result.encoded_command_mask, 0U);
+  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, first));
+  EXPECT_EQ(first.data[DB3], 0x89U);
+
+  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, second));
+  EXPECT_EQ(second.data[DB3], 0x89U);
 }
 
 void tx_builder_clears_external_room_temperature_override() {
   MhiCommandState command{};
   MhiTxRuntime runtime{};
-  runtime.room_temp_override_raw = 0x9DU;
   MhiTxBuildConfig config{};
-  MhiFrameBuffer out{};
-  MhiTxBuildResult result{};
+  MhiFrameBuffer frame{};
 
-  command.room_temp_override_set = true;
-  command.room_temp_override_raw = 0xFFU;
+  config.frame_size = kMhiFrame33Bytes;
+  runtime.room_temp_override_raw = 0x91U;
+  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, frame));
+  EXPECT_EQ(frame.data[DB3], 0x91U);
 
-  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, out, result));
-  EXPECT_EQ(out.data[DB3], 0xFFU);
-  EXPECT_EQ(runtime.room_temp_override_raw, 0xFFU);
-  EXPECT_EQ(result.encoded_command_mask, static_cast<uint32_t>(MHI_COMMAND_ROOM_TEMP_OVERRIDE));
+  runtime.room_temp_override_raw = 0xFFU;
+  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, frame));
+  EXPECT_EQ(frame.data[DB3], 0xFFU);
 }
 
 }  // namespace mhi_unit_tests

--- a/tests/unit/test_tx_builder.cpp
+++ b/tests/unit/test_tx_builder.cpp
@@ -233,4 +233,43 @@ void tx_builder_preserves_horizontal_context_for_3d_auto_command() {
   EXPECT_FALSE(command.has_pending_command());
 }
 
+
+
+void tx_builder_persists_external_room_temperature_override() {
+  MhiCommandState command{};
+  command.room_temp_override_set = true;
+  command.room_temp_override_raw = 0x9DU;  // 24.0C: (24 * 4) + 61.
+
+  MhiTxRuntime runtime{};
+  MhiTxBuildConfig config{};
+  MhiFrameBuffer out{};
+  MhiTxBuildResult result{};
+
+  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, out, result));
+  EXPECT_EQ(out.data[DB3], 0x9DU);
+  EXPECT_EQ(result.encoded_command_mask, static_cast<uint32_t>(MHI_COMMAND_ROOM_TEMP_OVERRIDE));
+  EXPECT_FALSE(command.room_temp_override_set);
+
+  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, out, result));
+  EXPECT_EQ(out.data[DB3], 0x9DU);
+  EXPECT_EQ(result.encoded_command_mask, 0U);
+}
+
+void tx_builder_clears_external_room_temperature_override() {
+  MhiCommandState command{};
+  MhiTxRuntime runtime{};
+  runtime.room_temp_override_raw = 0x9DU;
+  MhiTxBuildConfig config{};
+  MhiFrameBuffer out{};
+  MhiTxBuildResult result{};
+
+  command.room_temp_override_set = true;
+  command.room_temp_override_raw = 0xFFU;
+
+  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, out, result));
+  EXPECT_EQ(out.data[DB3], 0xFFU);
+  EXPECT_EQ(runtime.room_temp_override_raw, 0xFFU);
+  EXPECT_EQ(result.encoded_command_mask, static_cast<uint32_t>(MHI_COMMAND_ROOM_TEMP_OVERRIDE));
+}
+
 }  // namespace mhi_unit_tests


### PR DESCRIPTION
- Restored SetExternalRoomTemperatureAction support in the Redux codebase.
- Reconnected external_temperature_sensor to the MHI component using a sensor state callback.
- Applies the current external sensor value during startup when available.
- Keeps the encoded external room temperature in DB3 across outgoing MISO frames instead of treating it as a one-shot command.
- Restores DB3 to 0xFF when the external sensor becomes unavailable or publishes NaN, allowing the AC to return to its internal room-temperature sensor.
- Added startup and runtime logging for external-temperature configuration and updates.
- Added compile coverage using the direct external_temperature_sensor YAML configuration.
- Confirmed working with a Home Assistant sensor after a clean rebuild.