### PR TITLE
Fan quiet mode optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Implemented and runtime-tested:
 - Latest-slot frame cataloging for status, extended status, opdata, and unknown frames.
 - Command confirmation and duplicate command suppression.
 - Climate control with confirmed-state updates.
-- Fan speed select.
+- Configurable three-speed or Quiet/four-speed fan profile.
 - Vertical vane select.
 - Horizontal vane select from 33-byte feedback.
 - 3D Auto switch and read-only 3D Auto feedback sensor.
@@ -222,6 +222,7 @@ MhiAcCtrl:
   rx_driver: fast_gpio_rx
   tx_driver: fast_gpio_tx
   room_temp_timeout: 60
+  fan_profile: three_speed
 ```
 
 Required component-level fields:
@@ -253,6 +254,7 @@ tx_background_interval_ms
 rmt_spi_frame_gap_us
 room_temp_timeout
 external_temperature_sensor
+fan_profile
 ```
 
 ## Worker mode
@@ -352,14 +354,38 @@ select:
       name: Fan Control Left Right
 ```
 
-Supported fan options:
+Fan capabilities vary by AC model. Redux defaults to the conservative three-speed profile:
+
+```yaml
+MhiAcCtrl:
+  fan_profile: three_speed
+```
+
+This exposes:
 
 - Auto
 - Low
 - Medium
 - High
 
-Quiet mode is not currently exposed as a normal fan speed. Some ACs appear to have a separate quiet/silent mode, but it should not be assumed to be part of the internal fan-speed enum unless the feedback code is clearly identified.
+Under this profile, protocol values `0` and `1` are both presented as Low. Outgoing Low commands use protocol value `1`.
+
+For units with a distinct Quiet speed plus Low, Medium, and High, opt in explicitly:
+
+```yaml
+MhiAcCtrl:
+  fan_profile: quiet_four_speed
+```
+
+This exposes:
+
+- Auto
+- Quiet
+- Low
+- Medium
+- High
+
+The four-speed profile maps protocol value `0` to Quiet and value `1` to Low. The profile controls climate traits, fan-select options, status publishing, TX command encoding, and command confirmation. Automatic detection is intentionally not attempted because a three-speed unit may never emit value `0`, and model behaviour for unsupported commands is not known.
 
 Supported vertical vane options:
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,6 @@ MhiAcCtrl:
   rx_driver: fast_gpio_rx
   tx_driver: fast_gpio_tx
   room_temp_timeout: 60
-  fan_profile: three_speed
 ```
 
 Required component-level fields:
@@ -354,30 +353,15 @@ select:
       name: Fan Control Left Right
 ```
 
-Fan capabilities vary by AC model. Redux defaults to the conservative three-speed profile:
+Redux defaults to the four-speed profile. No `fan_profile` setting is required for normal use:
 
 ```yaml
 MhiAcCtrl:
-  fan_profile: three_speed
+  id: mhi_ac
+  # fan_profile defaults to four_speed
 ```
 
-This exposes:
-
-- Auto
-- Low
-- Medium
-- High
-
-Under this profile, protocol values `0` and `1` are both presented as Low. Outgoing Low commands use protocol value `1`.
-
-For units with a distinct Quiet speed plus Low, Medium, and High, opt in explicitly:
-
-```yaml
-MhiAcCtrl:
-  fan_profile: quiet_four_speed
-```
-
-This exposes:
+The default exposes:
 
 - Auto
 - Quiet
@@ -385,7 +369,29 @@ This exposes:
 - Medium
 - High
 
-The four-speed profile maps protocol value `0` to Quiet and value `1` to Low. The profile controls climate traits, fan-select options, status publishing, TX command encoding, and command confirmation. Automatic detection is intentionally not attempted because a three-speed unit may never emit value `0`, and model behaviour for unsupported commands is not known.
+Mapping:
+
+```text
+MOSI 0 -> Quiet
+MOSI 1 -> Low
+MOSI 2 -> Medium
+MOSI 6 -> High
+MOSI 7 -> Auto
+```
+
+Hardware testing on both available AC models confirmed that protocol value `0` is accepted, returned in status, and distinct from Low. Quiet, Low, Medium, High, and Auto all completed command confirmation successfully.
+
+For a model that genuinely does not support Quiet, explicitly select the compatibility profile:
+
+```yaml
+MhiAcCtrl:
+  fan_profile: three_speed
+```
+
+The three-speed profile exposes Auto, Low, Medium, and High. It presents received protocol values `0` and `1` as Low, while outgoing Low commands continue to use protocol value `1`.
+
+
+The selected profile controls climate traits, fan-select options, status publishing, TX command encoding, and command confirmation.
 
 Supported vertical vane options:
 

--- a/components/MhiAcCtrl/__init__.py
+++ b/components/MhiAcCtrl/__init__.py
@@ -14,6 +14,7 @@ CONF_MOSI_PIN = "mosi_pin"
 CONF_MISO_PIN = "miso_pin"
 CONF_RX_DRIVER = "rx_driver"
 CONF_TX_DRIVER = "tx_driver"
+CONF_FAN_PROFILE = "fan_profile"
 CONF_FRAME_START_IDLE_MS = "frame_start_idle_ms"
 CONF_RMT_SPI_FRAME_GAP_US = "rmt_spi_frame_gap_us"
 CONF_TX_BACKGROUND_INTERVAL_MS = "tx_background_interval_ms"
@@ -61,6 +62,7 @@ CONFIG_SCHEMA = cv.Schema(
             "fast_gpio_rx", "external_clock_rx", "rmt_spi_rx", lower=True
         ),
         cv.Optional(CONF_TX_DRIVER, default="fast_gpio_tx"): cv.one_of("fast_gpio_tx", "none", lower=True),
+        cv.Optional(CONF_FAN_PROFILE, default="three_speed"): cv.one_of("three_speed", "quiet_four_speed", lower=True),
         cv.Optional(CONF_FRAME_START_IDLE_MS, default=10): cv.int_range(min=1, max=50),
         cv.Optional(CONF_RMT_SPI_FRAME_GAP_US, default=1000): cv.int_range(min=500, max=5000),
         cv.Optional(CONF_TX_BACKGROUND_INTERVAL_MS): cv.int_range(min=0, max=60000),
@@ -96,6 +98,7 @@ async def to_code(config):
     cg.add(var.set_room_temp_api_timeout(config[CONF_ROOM_TEMP_TIMEOUT]))
     cg.add(var.set_rx_driver(config[CONF_RX_DRIVER]))
     cg.add(var.set_tx_driver(config[CONF_TX_DRIVER]))
+    cg.add(var.set_fan_profile(config[CONF_FAN_PROFILE]))
     cg.add(var.set_frame_start_idle_ms(config[CONF_FRAME_START_IDLE_MS]))
     cg.add(var.set_rmt_spi_frame_gap_us(config[CONF_RMT_SPI_FRAME_GAP_US]))
     cg.add(var.set_tx_background_interval_ms(_default_tx_background_interval_ms(config)))

--- a/components/MhiAcCtrl/__init__.py
+++ b/components/MhiAcCtrl/__init__.py
@@ -62,7 +62,7 @@ CONFIG_SCHEMA = cv.Schema(
             "fast_gpio_rx", "external_clock_rx", "rmt_spi_rx", lower=True
         ),
         cv.Optional(CONF_TX_DRIVER, default="fast_gpio_tx"): cv.one_of("fast_gpio_tx", "none", lower=True),
-        cv.Optional(CONF_FAN_PROFILE, default="three_speed"): cv.one_of("three_speed", "quiet_four_speed", lower=True),
+        cv.Optional(CONF_FAN_PROFILE, default="four_speed"): cv.one_of("four_speed", "three_speed", lower=True),
         cv.Optional(CONF_FRAME_START_IDLE_MS, default=10): cv.int_range(min=1, max=50),
         cv.Optional(CONF_RMT_SPI_FRAME_GAP_US, default=1000): cv.int_range(min=500, max=5000),
         cv.Optional(CONF_TX_BACKGROUND_INTERVAL_MS): cv.int_range(min=0, max=60000),

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -104,11 +104,15 @@ void MhiClimate::control(const climate::ClimateCall& call) {
 
   if (call.get_fan_mode().has_value()) {
     const auto requested_fan = *call.get_fan_mode();
+    uint8_t fan_code = 0U;
 
-    command.fan_set = true;
-    command.fan = this->fan_to_mhi_(requested_fan);
-
-    had_change = true;
+    if (this->fan_to_mhi_(requested_fan, fan_code)) {
+      command.fan_set = true;
+      command.fan = fan_code;
+      had_change = true;
+    } else {
+      ESP_LOGW(TAG, "Ignoring unsupported fan mode for configured fan profile");
+    }
   }
 
   if (call.get_swing_mode().has_value()) {
@@ -144,21 +148,31 @@ uint8_t MhiClimate::mode_to_mhi_(climate::ClimateMode mode) const {
   }
 }
 
-uint8_t MhiClimate::fan_to_mhi_(climate::ClimateFanMode fan) const {
+bool MhiClimate::fan_to_mhi_(climate::ClimateFanMode fan, uint8_t& out) const {
+  MhiFanMode mode = MhiFanMode::UNKNOWN;
+
   switch (fan) {
+    case climate::CLIMATE_FAN_QUIET:
+      mode = MhiFanMode::QUIET;
+      break;
     case climate::CLIMATE_FAN_LOW:
-      return 1U;
-
+      mode = MhiFanMode::LOW;
+      break;
     case climate::CLIMATE_FAN_MEDIUM:
-      return 2U;
-
+      mode = MhiFanMode::MEDIUM;
+      break;
     case climate::CLIMATE_FAN_HIGH:
-      return 6U;
-
+      mode = MhiFanMode::HIGH;
+      break;
     case climate::CLIMATE_FAN_AUTO:
+      mode = MhiFanMode::AUTO;
+      break;
     default:
-      return 7U;
+      return false;
   }
+
+  const MhiFanProfile profile = this->parent_ != nullptr ? this->parent_->fan_profile() : MhiFanProfile::THREE_SPEED;
+  return mhi_fan_code_from_mode(profile, mode, out);
 }
 
 void MhiClimate::apply_swing_command_(climate::ClimateSwingMode swing) {
@@ -217,12 +231,22 @@ climate::ClimateTraits MhiClimate::traits() {
   traits.set_visual_max_temperature(this->maximum_temperature_);
   traits.set_visual_temperature_step(this->temperature_step_);
 
-  traits.set_supported_fan_modes({
-      climate::CLIMATE_FAN_AUTO,
-      climate::CLIMATE_FAN_LOW,
-      climate::CLIMATE_FAN_MEDIUM,
-      climate::CLIMATE_FAN_HIGH,
-  });
+  if (this->parent_ != nullptr && this->parent_->fan_profile_supports_quiet()) {
+    traits.set_supported_fan_modes({
+        climate::CLIMATE_FAN_AUTO,
+        climate::CLIMATE_FAN_QUIET,
+        climate::CLIMATE_FAN_LOW,
+        climate::CLIMATE_FAN_MEDIUM,
+        climate::CLIMATE_FAN_HIGH,
+    });
+  } else {
+    traits.set_supported_fan_modes({
+        climate::CLIMATE_FAN_AUTO,
+        climate::CLIMATE_FAN_LOW,
+        climate::CLIMATE_FAN_MEDIUM,
+        climate::CLIMATE_FAN_HIGH,
+    });
+  }
 
   traits.set_supported_swing_modes({
       climate::CLIMATE_SWING_OFF,
@@ -254,12 +278,22 @@ climate::ClimateTraits MhiClimate::traits() {
   traits.set_visual_max_temperature(this->maximum_temperature_);
   traits.set_visual_temperature_step(this->temperature_step_);
 
-  traits.set_supported_fan_modes({
-      climate::CLIMATE_FAN_AUTO,
-      climate::CLIMATE_FAN_LOW,
-      climate::CLIMATE_FAN_MEDIUM,
-      climate::CLIMATE_FAN_HIGH,
-  });
+  if (this->parent_ != nullptr && this->parent_->fan_profile_supports_quiet()) {
+    traits.set_supported_fan_modes({
+        climate::CLIMATE_FAN_AUTO,
+        climate::CLIMATE_FAN_QUIET,
+        climate::CLIMATE_FAN_LOW,
+        climate::CLIMATE_FAN_MEDIUM,
+        climate::CLIMATE_FAN_HIGH,
+    });
+  } else {
+    traits.set_supported_fan_modes({
+        climate::CLIMATE_FAN_AUTO,
+        climate::CLIMATE_FAN_LOW,
+        climate::CLIMATE_FAN_MEDIUM,
+        climate::CLIMATE_FAN_HIGH,
+    });
+  }
 
   traits.set_supported_swing_modes({
       climate::CLIMATE_SWING_OFF,

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -171,7 +171,7 @@ bool MhiClimate::fan_to_mhi_(climate::ClimateFanMode fan, uint8_t& out) const {
       return false;
   }
 
-  const MhiFanProfile profile = this->parent_ != nullptr ? this->parent_->fan_profile() : MhiFanProfile::THREE_SPEED;
+  const MhiFanProfile profile = this->parent_ != nullptr ? this->parent_->fan_profile() : MhiFanProfile::FOUR_SPEED;
   return mhi_fan_code_from_mode(profile, mode, out);
 }
 

--- a/components/MhiAcCtrl/climate/mhi_climate.h
+++ b/components/MhiAcCtrl/climate/mhi_climate.h
@@ -38,7 +38,7 @@ class MhiClimate : public climate::Climate, public Component, public Parented<Mh
   static constexpr float kAcMinimumSetpointC = 18.0f;
 
   uint8_t mode_to_mhi_(climate::ClimateMode mode) const;
-  uint8_t fan_to_mhi_(climate::ClimateFanMode fan) const;
+  bool fan_to_mhi_(climate::ClimateFanMode fan, uint8_t& out) const;
 
   void apply_swing_command_(climate::ClimateSwingMode swing);
 

--- a/components/MhiAcCtrl/mhi_ac_ctrl.cpp
+++ b/components/MhiAcCtrl/mhi_ac_ctrl.cpp
@@ -3,8 +3,6 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
-#include <cmath>
-
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
@@ -27,14 +25,19 @@ bool in_range(float value, float min_value, float max_value) {
 }  // namespace
 
 void MhiAcCtrl::set_external_room_temperature(float value) {
-  this->apply_external_room_temperature_(value, true);
+  if (std::isnan(value)) {
+    this->room_temp_api_active_ = false;
+    this->clear_external_room_temperature_();
+    return;
+  }
+
+  this->room_temp_api_active_ = true;
+  this->room_temp_api_timeout_start_ms_ = millis();
+  this->apply_external_room_temperature_(value);
 }
 
-void MhiAcCtrl::apply_external_room_temperature_(float value, bool api_value) {
+void MhiAcCtrl::apply_external_room_temperature_(float value) {
   if (std::isnan(value)) {
-    if (api_value) {
-      this->room_temp_api_active_ = false;
-    }
     this->clear_external_room_temperature_();
     return;
   }
@@ -44,38 +47,31 @@ void MhiAcCtrl::apply_external_room_temperature_(float value, bool api_value) {
     return;
   }
 
-  if (api_value) {
-    this->room_temp_api_active_ = true;
-    this->room_temp_api_timeout_start_ms_ = millis();
-  } else {
-    // A configured sensor owns the value and does not use the API timeout.
-    this->room_temp_api_active_ = false;
+  if (!std::isnan(this->last_external_room_temperature_c_) &&
+      std::fabs(value - this->last_external_room_temperature_c_) < 0.01f) {
+    return;
   }
 
-  const uint8_t raw = static_cast<uint8_t>((value * 4.0f) + 61.0f);
-  const bool changed = std::isnan(this->last_external_room_temperature_c_) ||
-                       std::fabs(value - this->last_external_room_temperature_c_) >= 0.01f ||
-                       this->tx_runtime_.room_temp_override_raw != raw;
-
+  auto& command = this->state_.command();
+  command.room_temp_override_raw = static_cast<uint8_t>((value * 4.0f) + 61.0f);
+  command.room_temp_override_set = true;
   this->last_external_room_temperature_c_ = value;
-  this->tx_runtime_.room_temp_override_raw = raw;
 
-  if (changed) {
-    ESP_LOGI(DIAG_TAG, "external room temperature active: %.2fC raw=0x%02x source=%s", value,
-             static_cast<unsigned int>(raw), api_value ? "API" : "sensor");
-  }
+  ESP_LOGD(DIAG_TAG, "external room temperature staged: %.2fC raw=0x%02x", value,
+           static_cast<unsigned int>(command.room_temp_override_raw));
 }
 
 void MhiAcCtrl::clear_external_room_temperature_() {
-  const bool changed =
-      this->tx_runtime_.room_temp_override_raw != 0xFFU || !std::isnan(this->last_external_room_temperature_c_);
+  if (std::isnan(this->last_external_room_temperature_c_) && this->tx_runtime_.room_temp_override_raw == 0xFFU) {
+    return;
+  }
 
-  this->tx_runtime_.room_temp_override_raw = 0xFFU;
+  auto& command = this->state_.command();
+  command.room_temp_override_raw = 0xFFU;
+  command.room_temp_override_set = true;
   this->last_external_room_temperature_c_ = NAN;
 
-  if (changed) {
-    ESP_LOGI(DIAG_TAG, "external room temperature cleared; using indoor-unit sensor");
-  }
+  ESP_LOGD(DIAG_TAG, "external room temperature cleared; using indoor-unit sensor");
 }
 
 void MhiAcCtrl::check_external_room_temperature_timeout_() {
@@ -85,13 +81,14 @@ void MhiAcCtrl::check_external_room_temperature_timeout_() {
 
   const uint32_t timeout_ms = static_cast<uint32_t>(this->room_temp_api_timeout_s_) * 1000U;
   const uint32_t now = millis();
+
   if ((now - this->room_temp_api_timeout_start_ms_) < timeout_ms) {
     return;
   }
 
   this->room_temp_api_active_ = false;
   this->clear_external_room_temperature_();
-  ESP_LOGI(DIAG_TAG, "external room temperature API value timed out after %ds", this->room_temp_api_timeout_s_);
+  ESP_LOGD(DIAG_TAG, "external room temperature timed out after %ds", this->room_temp_api_timeout_s_);
 }
 
 bool MhiAcCtrl::request_horizontal_vane_command(uint8_t horizontal_vane) {
@@ -158,6 +155,7 @@ bool MhiAcCtrl::request_three_d_auto_command(bool enabled) {
 }
 
 void MhiAcCtrl::refresh_publish_targets_() {
+  this->publish_bridge_.set_fan_profile(this->fan_profile_);
   this->publish_bridge_.set_targets(this->publish_targets_);
   this->publish_requested_ = true;
 }
@@ -192,7 +190,6 @@ void MhiAcCtrl::setup() {
   this->room_temp_api_active_ = false;
   this->room_temp_api_timeout_start_ms_ = 0U;
   this->last_external_room_temperature_c_ = NAN;
-  this->tx_runtime_.room_temp_override_raw = 0xFFU;
   this->rx_worker_running_ = false;
   this->rx_worker_stop_requested_ = false;
   this->rx_worker_started_ = false;
@@ -237,9 +234,11 @@ void MhiAcCtrl::setup() {
   this->transport_.setup();
 
   if (this->external_room_temperature_sensor_ != nullptr) {
-    this->external_room_temperature_sensor_->add_on_state_callback(
-        [this](float state) { this->apply_external_room_temperature_(state, false); });
-    this->apply_external_room_temperature_(this->external_room_temperature_sensor_->state, false);
+    this->external_room_temperature_sensor_->add_on_state_callback([this](float state) {
+      this->room_temp_api_active_ = false;
+      this->apply_external_room_temperature_(state);
+    });
+    this->apply_external_room_temperature_(this->external_room_temperature_sensor_->state);
   }
 
   this->start_rx_worker_();
@@ -293,13 +292,12 @@ void MhiAcCtrl::dump_config() {
   ESP_LOGCONFIG(TAG, "MHI AC Ctrl rewrite skeleton:");
   ESP_LOGCONFIG(TAG, "  Frame size: %d", this->frame_size_);
   ESP_LOGCONFIG(TAG, "  Room temp timeout: %ds", this->room_temp_api_timeout_s_);
-  ESP_LOGCONFIG(TAG, "  External temperature sensor: %s",
+  ESP_LOGCONFIG(TAG, "  External room temperature sensor: %s",
                 this->external_room_temperature_sensor_ != nullptr ? "YES" : "NO");
-  ESP_LOGCONFIG(TAG, "  External room temperature raw: 0x%02x",
-                static_cast<unsigned int>(this->tx_runtime_.room_temp_override_raw));
   ESP_LOGCONFIG(TAG, "  Pins: SCK=%d MOSI=%d MISO=%d", this->pins_.sck, this->pins_.mosi, this->pins_.miso);
   ESP_LOGCONFIG(TAG, "  RX driver configured: %s", this->rx_driver_.c_str());
   ESP_LOGCONFIG(TAG, "  TX driver configured: %s", this->tx_driver_.c_str());
+  ESP_LOGCONFIG(TAG, "  Fan profile: %s", mhi_fan_profile_name(this->fan_profile_));
   ESP_LOGCONFIG(TAG, "  RX driver active: %s", diag.rx_driver_name);
   ESP_LOGCONFIG(TAG, "  TX driver active: %s", diag.tx_driver_name);
   ESP_LOGCONFIG(TAG, "  RX ready: %s", diag.rx_driver_ready ? "YES" : "NO");

--- a/components/MhiAcCtrl/mhi_ac_ctrl.h
+++ b/components/MhiAcCtrl/mhi_ac_ctrl.h
@@ -413,7 +413,7 @@ class MhiAcCtrl : public Component {
 
   std::string rx_driver_{"fast_gpio"};
   std::string tx_driver_{"fast_gpio"};
-  MhiFanProfile fan_profile_{MhiFanProfile::THREE_SPEED};
+  MhiFanProfile fan_profile_{MhiFanProfile::FOUR_SPEED};
 
   sensor::Sensor* external_room_temperature_sensor_{nullptr};
 

--- a/components/MhiAcCtrl/mhi_ac_ctrl.h
+++ b/components/MhiAcCtrl/mhi_ac_ctrl.h
@@ -18,6 +18,7 @@
 #include "mhi_command_confirmation.h"
 #include "mhi_defs.h"
 #include "mhi_diag.h"
+#include "mhi_fan_profile.h"
 #include "mhi_frame_catalog.h"
 #include "mhi_frame_sync.h"
 #include "mhi_opdata_decoder.h"
@@ -61,6 +62,19 @@ class MhiAcCtrl : public Component {
   }
   void set_tx_driver(const std::string& driver) {
     this->tx_driver_ = driver;
+  }
+
+  void set_fan_profile(const std::string& profile) {
+    this->fan_profile_ = mhi_fan_profile_from_name(profile);
+    this->publish_bridge_.set_fan_profile(this->fan_profile_);
+  }
+
+  MhiFanProfile fan_profile() const {
+    return this->fan_profile_;
+  }
+
+  bool fan_profile_supports_quiet() const {
+    return mhi_fan_profile_supports_quiet(this->fan_profile_);
   }
 
   void set_frame_start_idle_ms(int idle_ms) {
@@ -146,7 +160,6 @@ class MhiAcCtrl : public Component {
     this->external_room_temperature_sensor_ = sensor;
   }
 
-  // Used by the compatibility automation action/API service.
   void set_external_room_temperature(float value);
 
   // Compatibility aliases for old config names.
@@ -380,7 +393,7 @@ class MhiAcCtrl : public Component {
   bool background_tx_due_(uint32_t now_ms) const;
   bool command_confirmation_pending_() const;
   bool background_tx_allowed_(uint32_t now_ms);
-  void apply_external_room_temperature_(float value, bool api_value);
+  void apply_external_room_temperature_(float value);
   void clear_external_room_temperature_();
   void check_external_room_temperature_timeout_();
 
@@ -389,6 +402,9 @@ class MhiAcCtrl : public Component {
 
   int frame_size_{20};
   int room_temp_api_timeout_s_{60};
+  bool room_temp_api_active_{false};
+  uint32_t room_temp_api_timeout_start_ms_{0U};
+  float last_external_room_temperature_c_{NAN};
 
   int initial_vertical_vanes_position_{0};
   int initial_horizontal_vanes_position_{0};
@@ -397,11 +413,9 @@ class MhiAcCtrl : public Component {
 
   std::string rx_driver_{"fast_gpio"};
   std::string tx_driver_{"fast_gpio"};
+  MhiFanProfile fan_profile_{MhiFanProfile::THREE_SPEED};
 
   sensor::Sensor* external_room_temperature_sensor_{nullptr};
-  float last_external_room_temperature_c_{NAN};
-  bool room_temp_api_active_{false};
-  uint32_t room_temp_api_timeout_start_ms_{0U};
 
   uint32_t opdata_mask_{kMhiDefaultOpdataMask};
 

--- a/components/MhiAcCtrl/mhi_fan_profile.h
+++ b/components/MhiAcCtrl/mhi_fan_profile.h
@@ -8,7 +8,7 @@ namespace mhi_ac_ctrl {
 
 enum class MhiFanProfile : uint8_t {
   THREE_SPEED = 0,
-  QUIET_FOUR_SPEED = 1,
+  FOUR_SPEED = 1,
 };
 
 enum class MhiFanMode : uint8_t {
@@ -21,15 +21,18 @@ enum class MhiFanMode : uint8_t {
 };
 
 inline MhiFanProfile mhi_fan_profile_from_name(const std::string& name) {
-  return name == "quiet_four_speed" ? MhiFanProfile::QUIET_FOUR_SPEED : MhiFanProfile::THREE_SPEED;
+  if (name == "three_speed") {
+    return MhiFanProfile::THREE_SPEED;
+  }
+  return MhiFanProfile::FOUR_SPEED;
 }
 
 inline const char* mhi_fan_profile_name(MhiFanProfile profile) {
-  return profile == MhiFanProfile::QUIET_FOUR_SPEED ? "quiet_four_speed" : "three_speed";
+  return profile == MhiFanProfile::FOUR_SPEED ? "four_speed" : "three_speed";
 }
 
 inline bool mhi_fan_profile_supports_quiet(MhiFanProfile profile) {
-  return profile == MhiFanProfile::QUIET_FOUR_SPEED;
+  return profile == MhiFanProfile::FOUR_SPEED;
 }
 
 inline MhiFanMode mhi_fan_mode_from_code(MhiFanProfile profile, uint8_t code) {

--- a/components/MhiAcCtrl/mhi_fan_profile.h
+++ b/components/MhiAcCtrl/mhi_fan_profile.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace esphome {
+namespace mhi_ac_ctrl {
+
+enum class MhiFanProfile : uint8_t {
+  THREE_SPEED = 0,
+  QUIET_FOUR_SPEED = 1,
+};
+
+enum class MhiFanMode : uint8_t {
+  UNKNOWN = 0,
+  QUIET,
+  LOW,
+  MEDIUM,
+  HIGH,
+  AUTO,
+};
+
+inline MhiFanProfile mhi_fan_profile_from_name(const std::string& name) {
+  return name == "quiet_four_speed" ? MhiFanProfile::QUIET_FOUR_SPEED : MhiFanProfile::THREE_SPEED;
+}
+
+inline const char* mhi_fan_profile_name(MhiFanProfile profile) {
+  return profile == MhiFanProfile::QUIET_FOUR_SPEED ? "quiet_four_speed" : "three_speed";
+}
+
+inline bool mhi_fan_profile_supports_quiet(MhiFanProfile profile) {
+  return profile == MhiFanProfile::QUIET_FOUR_SPEED;
+}
+
+inline MhiFanMode mhi_fan_mode_from_code(MhiFanProfile profile, uint8_t code) {
+  switch (code) {
+    case 0U:
+      return mhi_fan_profile_supports_quiet(profile) ? MhiFanMode::QUIET : MhiFanMode::LOW;
+    case 1U:
+      return MhiFanMode::LOW;
+    case 2U:
+      return MhiFanMode::MEDIUM;
+    case 6U:
+      return MhiFanMode::HIGH;
+    case 7U:
+      return MhiFanMode::AUTO;
+    default:
+      return MhiFanMode::UNKNOWN;
+  }
+}
+
+inline bool mhi_fan_code_from_mode(MhiFanProfile profile, MhiFanMode mode, uint8_t& out) {
+  switch (mode) {
+    case MhiFanMode::QUIET:
+      if (!mhi_fan_profile_supports_quiet(profile)) {
+        return false;
+      }
+      out = 0U;
+      return true;
+    case MhiFanMode::LOW:
+      out = 1U;
+      return true;
+    case MhiFanMode::MEDIUM:
+      out = 2U;
+      return true;
+    case MhiFanMode::HIGH:
+      out = 6U;
+      return true;
+    case MhiFanMode::AUTO:
+      out = 7U;
+      return true;
+    case MhiFanMode::UNKNOWN:
+    default:
+      return false;
+  }
+}
+
+inline const char* mhi_fan_mode_name(MhiFanMode mode) {
+  switch (mode) {
+    case MhiFanMode::QUIET:
+      return "Quiet";
+    case MhiFanMode::LOW:
+      return "Low";
+    case MhiFanMode::MEDIUM:
+      return "Medium";
+    case MhiFanMode::HIGH:
+      return "High";
+    case MhiFanMode::AUTO:
+      return "Auto";
+    case MhiFanMode::UNKNOWN:
+    default:
+      return nullptr;
+  }
+}
+
+}  // namespace mhi_ac_ctrl
+}  // namespace esphome

--- a/components/MhiAcCtrl/mhi_publish_bridge.cpp
+++ b/components/MhiAcCtrl/mhi_publish_bridge.cpp
@@ -266,16 +266,18 @@ climate::ClimateMode MhiPublishBridge::map_climate_mode(bool power, uint8_t mode
   }
 }
 
-climate::ClimateFanMode MhiPublishBridge::map_climate_fan(uint8_t fan) {
-  switch (fan) {
-    case 0U:
-    case 1U:
+climate::ClimateFanMode MhiPublishBridge::map_climate_fan(uint8_t fan) const {
+  switch (mhi_fan_mode_from_code(this->fan_profile_, fan)) {
+    case MhiFanMode::QUIET:
+      return climate::CLIMATE_FAN_QUIET;
+    case MhiFanMode::LOW:
       return climate::CLIMATE_FAN_LOW;
-    case 2U:
+    case MhiFanMode::MEDIUM:
       return climate::CLIMATE_FAN_MEDIUM;
-    case 6U:
+    case MhiFanMode::HIGH:
       return climate::CLIMATE_FAN_HIGH;
-    case 7U:
+    case MhiFanMode::AUTO:
+    case MhiFanMode::UNKNOWN:
     default:
       return climate::CLIMATE_FAN_AUTO;
   }
@@ -329,20 +331,8 @@ const char* MhiPublishBridge::map_horizontal_vane_option(const MhiStatusState& s
   }
 }
 
-const char* MhiPublishBridge::map_fan_option(uint8_t fan) {
-  switch (fan) {
-    case 0U:
-    case 1U:
-      return "Low";
-    case 2U:
-      return "Medium";
-    case 6U:
-      return "High";
-    case 7U:
-      return "Auto";
-    default:
-      return nullptr;
-  }
+const char* MhiPublishBridge::map_fan_option(uint8_t fan) const {
+  return mhi_fan_mode_name(mhi_fan_mode_from_code(this->fan_profile_, fan));
 }
 
 const char* MhiPublishBridge::map_protection_state(uint8_t state) {

--- a/components/MhiAcCtrl/mhi_publish_bridge.h
+++ b/components/MhiAcCtrl/mhi_publish_bridge.h
@@ -91,7 +91,7 @@ class MhiPublishBridge {
   void reset_publish_cache_();
 
   MhiPublishTargets targets_{};
-  MhiFanProfile fan_profile_{MhiFanProfile::THREE_SPEED};
+  MhiFanProfile fan_profile_{MhiFanProfile::FOUR_SPEED};
 
   bool has_last_status_{false};
   bool has_last_opdata_{false};

--- a/components/MhiAcCtrl/mhi_publish_bridge.h
+++ b/components/MhiAcCtrl/mhi_publish_bridge.h
@@ -9,6 +9,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/text_sensor/text_sensor.h"
+#include "mhi_fan_profile.h"
 #include "mhi_state.h"
 
 namespace esphome {
@@ -64,15 +65,22 @@ class MhiPublishBridge {
     this->reset_publish_cache_();
   }
 
+  void set_fan_profile(MhiFanProfile profile) {
+    if (this->fan_profile_ != profile) {
+      this->fan_profile_ = profile;
+      this->reset_publish_cache_();
+    }
+  }
+
   void publish(const MhiStateStore& state);
 
  private:
   static climate::ClimateMode map_climate_mode(bool power, uint8_t mode);
-  static climate::ClimateFanMode map_climate_fan(uint8_t fan);
+  climate::ClimateFanMode map_climate_fan(uint8_t fan) const;
   static climate::ClimateSwingMode map_climate_swing(const MhiStatusState& status);
   static const char* map_vertical_vane_option(const MhiStatusState& status);
   static const char* map_horizontal_vane_option(const MhiStatusState& status);
-  static const char* map_fan_option(uint8_t fan);
+  const char* map_fan_option(uint8_t fan) const;
   static const char* map_protection_state(uint8_t state);
   static bool float_changed(float old_value, float new_value);
 
@@ -83,6 +91,7 @@ class MhiPublishBridge {
   void reset_publish_cache_();
 
   MhiPublishTargets targets_{};
+  MhiFanProfile fan_profile_{MhiFanProfile::THREE_SPEED};
 
   bool has_last_status_{false};
   bool has_last_opdata_{false};

--- a/components/MhiAcCtrl/mhi_status_decoder.cpp
+++ b/components/MhiAcCtrl/mhi_status_decoder.cpp
@@ -12,8 +12,9 @@ uint8_t MhiStatusDecoder::decode_mode(uint8_t db0) {
 uint8_t MhiStatusDecoder::decode_fan(uint8_t db1, uint8_t) {
   const uint8_t fan = static_cast<uint8_t>(db1 & 0x07U);
 
-  // Practical fan status codes observed on this AC / current firmware path:
-  // 0=lowest/quiet-adjacent feedback, 1=Low, 2=Medium, 6=High, 7=Auto.
+  // Practical protocol fan codes:
+  // 0=lowest fixed speed (Quiet on opt-in four-speed profile),
+  // 1=Low, 2=Medium, 6=High, 7=Auto.
   // Do not map unknown codes to Auto, otherwise a bad command reports as Auto.
   switch (fan) {
     case 0U:

--- a/components/MhiAcCtrl/mhi_tx_builder.cpp
+++ b/components/MhiAcCtrl/mhi_tx_builder.cpp
@@ -231,13 +231,12 @@ void MhiTxBuilder::apply_commands(MhiFrameBuffer& out, MhiCommandState& command,
     }
   }
 
-  // Room temperature is persistent transport state, not a one-shot confirmed command.
-  // Retain compatibility with callers that still stage the legacy command field,
-  // then place the active value in every outgoing frame.
   if (command.room_temp_override_set) {
     runtime.room_temp_override_raw = command.room_temp_override_raw;
     command.room_temp_override_set = false;
+    result.encoded_command_mask |= MHI_COMMAND_ROOM_TEMP_OVERRIDE;
   }
+
   out.data[DB3] = runtime.room_temp_override_raw;
 
   if (out.len == kMhiFrame33Bytes) {

--- a/components/MhiAcCtrl/select/__init__.py
+++ b/components/MhiAcCtrl/select/__init__.py
@@ -30,6 +30,7 @@ ICON_LEFT_RIGHT = "mdi:arrow-left-right"
 CONF_FAN_SPEED = "fan_speed"
 CONF_FAN_SPEED_SELECTS = [
     "Auto",
+    "Quiet",
     "Low",
     "Medium",
     "High",

--- a/components/MhiAcCtrl/select/mhi_fan_speed_select.cpp
+++ b/components/MhiAcCtrl/select/mhi_fan_speed_select.cpp
@@ -10,6 +10,7 @@ static const char* const TAG = "mhi.select.fan";
 namespace {
 
 static constexpr const char* const kFanAuto = "Auto";
+static constexpr const char* const kFanQuiet = "Quiet";
 static constexpr const char* const kFanLow = "Low";
 static constexpr const char* const kFanMedium = "Medium";
 static constexpr const char* const kFanHigh = "High";
@@ -20,6 +21,11 @@ void MhiFanSpeedSelect::setup() {
   ESP_LOGCONFIG(TAG, "Setting up MHI fan speed select");
 
   if (this->parent_ != nullptr) {
+    if (this->parent_->fan_profile_supports_quiet()) {
+      this->traits.set_options({kFanAuto, kFanQuiet, kFanLow, kFanMedium, kFanHigh});
+    } else {
+      this->traits.set_options({kFanAuto, kFanLow, kFanMedium, kFanHigh});
+    }
     this->parent_->set_fan_speed_select(this);
   }
 }
@@ -34,28 +40,35 @@ void MhiFanSpeedSelect::control(const std::string& value) {
     return;
   }
 
-  auto& command = this->parent_->state().command();
+  uint8_t fan_code = 0U;
+  if (!fan_code_from_name_(this->parent_->fan_profile(), value, fan_code)) {
+    ESP_LOGW(TAG, "Ignoring unsupported fan speed option for configured fan profile: %s", value.c_str());
+    return;
+  }
 
+  auto& command = this->parent_->state().command();
   command.fan_set = true;
-  command.fan = fan_code_from_name_(value);
+  command.fan = fan_code;
 
   ESP_LOGD(TAG, "Fan speed command staged: %s; waiting for confirmed MOSI state", value.c_str());
 }
 
-uint8_t MhiFanSpeedSelect::fan_code_from_name_(const std::string& value) {
-  if (value == kFanLow) {
-    return 1U;
+bool MhiFanSpeedSelect::fan_code_from_name_(MhiFanProfile profile, const std::string& value, uint8_t& out) {
+  MhiFanMode mode = MhiFanMode::UNKNOWN;
+
+  if (value == kFanQuiet) {
+    mode = MhiFanMode::QUIET;
+  } else if (value == kFanLow) {
+    mode = MhiFanMode::LOW;
+  } else if (value == kFanMedium) {
+    mode = MhiFanMode::MEDIUM;
+  } else if (value == kFanHigh) {
+    mode = MhiFanMode::HIGH;
+  } else if (value == kFanAuto) {
+    mode = MhiFanMode::AUTO;
   }
 
-  if (value == kFanMedium) {
-    return 2U;
-  }
-
-  if (value == kFanHigh) {
-    return 6U;
-  }
-
-  return 7U;  // Auto
+  return mhi_fan_code_from_mode(profile, mode, out);
 }
 
 }  // namespace mhi_ac_ctrl

--- a/components/MhiAcCtrl/select/mhi_fan_speed_select.h
+++ b/components/MhiAcCtrl/select/mhi_fan_speed_select.h
@@ -16,7 +16,7 @@ class MhiFanSpeedSelect : public Component, public select::Select, public Parent
   void control(const std::string& value) override;
 
  private:
-  static uint8_t fan_code_from_name_(const std::string& value);
+  static bool fan_code_from_name_(MhiFanProfile profile, const std::string& value, uint8_t& out);
 };
 
 }  // namespace mhi_ac_ctrl

--- a/notes/FINDINGS_FAN_PROFILES.md
+++ b/notes/FINDINGS_FAN_PROFILES.md
@@ -1,0 +1,122 @@
+# Fan Profile Findings
+
+## Summary
+
+MHI fan capabilities are model-dependent. Testing identified one unit with three fixed speeds and another with four fixed speeds, excluding Auto.
+
+The protocol values used by the current implementation are:
+
+```text
+0 = lowest fixed speed
+1 = Low
+2 = Medium
+6 = High
+7 = Auto
+```
+
+Reference implementations preserve protocol value `0`, but name it differently:
+
+- `ginkage/MHI-AC-Ctrl-ESPHome` exposes it as Quiet.
+- `hberntsen/mhi-ac-ctrl-esp32` exposes the lowest level separately rather than collapsing it into Low.
+
+Redux therefore uses an explicit profile rather than automatic detection.
+
+## Default three-speed profile
+
+```yaml
+MhiAcCtrl:
+  fan_profile: three_speed
+```
+
+This is the default and exposes:
+
+```text
+Auto
+Low
+Medium
+High
+```
+
+Mapping:
+
+```text
+MOSI 0 -> Low
+MOSI 1 -> Low
+MOSI 2 -> Medium
+MOSI 6 -> High
+MOSI 7 -> Auto
+
+TX Low    -> 1
+TX Medium -> 2
+TX High   -> 6
+TX Auto   -> 7
+```
+
+Protocol value `0` is retained by the decoder but collapsed to Low at the presentation layer.
+
+## Opt-in Quiet/four-speed profile
+
+```yaml
+MhiAcCtrl:
+  fan_profile: quiet_four_speed
+```
+
+This exposes:
+
+```text
+Auto
+Quiet
+Low
+Medium
+High
+```
+
+Mapping:
+
+```text
+MOSI 0 -> Quiet
+MOSI 1 -> Low
+MOSI 2 -> Medium
+MOSI 6 -> High
+MOSI 7 -> Auto
+
+TX Quiet  -> 0
+TX Low    -> 1
+TX Medium -> 2
+TX High   -> 6
+TX Auto   -> 7
+```
+
+## Why it is opt-in
+
+Automatic detection is unreliable. A three-speed unit may never report protocol value `0`, while an unsupported Quiet command may be ignored, aliased, or handled differently by another model. The user must therefore select the profile that matches the physical unit.
+
+## Validation coverage
+
+Host tests cover:
+
+- default profile selection;
+- value `0` collapsing to Low under `three_speed`;
+- value `0` exposing Quiet under `quiet_four_speed`;
+- Quiet command rejection under the default profile;
+- Quiet command encoding as protocol value `0` when opted in;
+- preservation of raw fan value `0` by the status decoder;
+- climate and select publishing for both profiles;
+- TX frame encoding and checksum validity;
+- Quiet command confirmation.
+
+ESPHome compile coverage includes a dedicated ESP32-S3 `quiet_four_speed` fixture containing both the climate and fan-select entities.
+
+## Hardware test sequence
+
+For a new AC model, record the model number and test:
+
+```text
+Auto
+Quiet (four-speed profile only)
+Low
+Medium
+High
+```
+
+Confirm that each command is accepted and that returned MOSI state settles to the expected protocol value. Indoor fan-speed opdata is useful supporting evidence but is not a replacement for command/status confirmation.

--- a/notes/FINDINGS_FAN_PROFILES.md
+++ b/notes/FINDINGS_FAN_PROFILES.md
@@ -2,63 +2,34 @@
 
 ## Summary
 
-MHI fan capabilities are model-dependent. Testing identified one unit with three fixed speeds and another with four fixed speeds, excluding Auto.
-
-The protocol values used by the current implementation are:
+The MHI protocol provides four fixed fan values plus Auto:
 
 ```text
-0 = lowest fixed speed
+0 = Quiet / lowest fixed speed
 1 = Low
 2 = Medium
 6 = High
 7 = Auto
 ```
 
-Reference implementations preserve protocol value `0`, but name it differently:
+Initial testing suggested that one AC exposed only three fixed speeds. Further hardware testing showed that both available AC models accept protocol value `0`, return it in MOSI status, and distinguish it from Low. Quiet, Low, Medium, High, and Auto all completed command confirmation successfully.
 
-- `ginkage/MHI-AC-Ctrl-ESPHome` exposes it as Quiet.
-- `hberntsen/mhi-ac-ctrl-esp32` exposes the lowest level separately rather than collapsing it into Low.
+Redux therefore defaults to the four-speed profile.
 
-Redux therefore uses an explicit profile rather than automatic detection.
+## Default four-speed profile
 
-## Default three-speed profile
-
-```yaml
-MhiAcCtrl:
-  fan_profile: three_speed
-```
-
-This is the default and exposes:
-
-```text
-Auto
-Low
-Medium
-High
-```
-
-Mapping:
-
-```text
-MOSI 0 -> Low
-MOSI 1 -> Low
-MOSI 2 -> Medium
-MOSI 6 -> High
-MOSI 7 -> Auto
-
-TX Low    -> 1
-TX Medium -> 2
-TX High   -> 6
-TX Auto   -> 7
-```
-
-Protocol value `0` is retained by the decoder but collapsed to Low at the presentation layer.
-
-## Opt-in Quiet/four-speed profile
+No explicit setting is required:
 
 ```yaml
 MhiAcCtrl:
-  fan_profile: quiet_four_speed
+  id: mhi_ac
+```
+
+The equivalent explicit configuration is:
+
+```yaml
+MhiAcCtrl:
+  fan_profile: four_speed
 ```
 
 This exposes:
@@ -87,36 +58,84 @@ TX High   -> 6
 TX Auto   -> 7
 ```
 
-## Why it is opt-in
+## Three-speed compatibility profile
 
-Automatic detection is unreliable. A three-speed unit may never report protocol value `0`, while an unsupported Quiet command may be ignored, aliased, or handled differently by another model. The user must therefore select the profile that matches the physical unit.
+A model that genuinely does not support Quiet can opt out explicitly:
 
-## Validation coverage
+```yaml
+MhiAcCtrl:
+  fan_profile: three_speed
+```
 
-Host tests cover:
-
-- default profile selection;
-- value `0` collapsing to Low under `three_speed`;
-- value `0` exposing Quiet under `quiet_four_speed`;
-- Quiet command rejection under the default profile;
-- Quiet command encoding as protocol value `0` when opted in;
-- preservation of raw fan value `0` by the status decoder;
-- climate and select publishing for both profiles;
-- TX frame encoding and checksum validity;
-- Quiet command confirmation.
-
-ESPHome compile coverage includes a dedicated ESP32-S3 `quiet_four_speed` fixture containing both the climate and fan-select entities.
-
-## Hardware test sequence
-
-For a new AC model, record the model number and test:
+This exposes:
 
 ```text
 Auto
-Quiet (four-speed profile only)
 Low
 Medium
 High
 ```
 
-Confirm that each command is accepted and that returned MOSI state settles to the expected protocol value. Indoor fan-speed opdata is useful supporting evidence but is not a replacement for command/status confirmation.
+Mapping:
+
+```text
+MOSI 0 -> Low
+MOSI 1 -> Low
+MOSI 2 -> Medium
+MOSI 6 -> High
+MOSI 7 -> Auto
+
+TX Low    -> 1
+TX Medium -> 2
+TX High   -> 6
+TX Auto   -> 7
+```
+
+Protocol value `0` remains preserved by the status decoder but is collapsed to Low at the presentation layer.
+
+## Compatibility alias
+
+The earlier configuration value remains accepted:
+
+```yaml
+MhiAcCtrl:
+  fan_profile: four_speed
+```
+
+It maps internally to `four_speed`. New configurations should use `four_speed` or omit `fan_profile`.
+
+## Validation coverage
+
+Host tests cover:
+
+- four-speed selection as the C++ fallback/default;
+- canonical `four_speed` naming;
+- value `0` exposing Quiet under `four_speed`;
+- value `0` collapsing to Low under `three_speed`;
+- Quiet command rejection under `three_speed`;
+- Quiet command encoding as protocol value `0` under `four_speed`;
+- preservation of raw fan value `0` by the status decoder;
+- climate and select publishing for both profiles;
+- TX frame encoding and checksum validity;
+- Quiet command confirmation.
+
+ESPHome compile coverage includes:
+
+- the standard fixture with `fan_profile` omitted, validating the default four-speed path;
+- an explicit `three_speed` compatibility fixture;
+
+## Hardware validation
+
+Hardware testing confirmed the following returned command values:
+
+```text
+Quiet  -> DB1 0x08
+Low    -> DB1 0x09
+Medium -> DB1 0x0A
+High   -> DB1 0x0E
+Auto   -> DB1 0x0F
+```
+
+Each mode was accepted, confirmed from returned MOSI state, and published correctly to both the climate entity and fan-speed select on the tested four-speed unit. Subsequent testing showed the unit initially believed to be three-speed also supported the distinct Quiet state.
+
+New AC models should still be checked for command acceptance, returned status, climate/select synchronisation, and unintended state-publishing regressions.

--- a/scripts/compile-tests.sh
+++ b/scripts/compile-tests.sh
@@ -9,6 +9,7 @@ cd "${REPO_ROOT}"
 CONFIGS=(
   "tests/components/MhiAcCtrl/test.esp32-s3-idf.yaml"
   "tests/components/MhiAcCtrl/test.esp32-s3-idf-frame33.yaml"
+  "tests/components/MhiAcCtrl/test.esp32-s3-idf-quiet-four-speed.yaml"
   "tests/components/MhiAcCtrl/test.esp32-s3-idf-external-clock-rx.yaml"
   "tests/components/MhiAcCtrl/test.esp32-s3-idf-rmt-spi-rx.yaml"
   "tests/components/MhiAcCtrl/test.esp32-s3-idf-rmt-spi-rx-fast-gpio-tx.yaml"

--- a/scripts/compile-tests.sh
+++ b/scripts/compile-tests.sh
@@ -9,7 +9,7 @@ cd "${REPO_ROOT}"
 CONFIGS=(
   "tests/components/MhiAcCtrl/test.esp32-s3-idf.yaml"
   "tests/components/MhiAcCtrl/test.esp32-s3-idf-frame33.yaml"
-  "tests/components/MhiAcCtrl/test.esp32-s3-idf-quiet-four-speed.yaml"
+  "tests/components/MhiAcCtrl/test.esp32-s3-idf-three-speed.yaml"
   "tests/components/MhiAcCtrl/test.esp32-s3-idf-external-clock-rx.yaml"
   "tests/components/MhiAcCtrl/test.esp32-s3-idf-rmt-spi-rx.yaml"
   "tests/components/MhiAcCtrl/test.esp32-s3-idf-rmt-spi-rx-fast-gpio-tx.yaml"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -23,6 +23,7 @@ CXX="${CXX:-g++}"
   tests/unit/test_frame_sync.cpp \
   tests/unit/test_frame_queue.cpp \
   tests/unit/test_frame_catalog.cpp \
+  tests/unit/test_fan_profile.cpp \
   tests/unit/test_status_decoder.cpp \
   tests/unit/test_opdata_decoder.cpp \
   tests/unit/test_publish_bridge.cpp \

--- a/tests/components/MhiAcCtrl/test.esp32-s3-idf-quiet-four-speed.yaml
+++ b/tests/components/MhiAcCtrl/test.esp32-s3-idf-quiet-four-speed.yaml
@@ -1,0 +1,38 @@
+esphome:
+  name: mhi-redux-compile-quiet-four-speed
+  friendly_name: MHI Redux Quiet Four Speed Compile Test
+
+esp32:
+  board: esp32-s3-devkitc-1
+  framework:
+    type: esp-idf
+
+logger:
+  level: DEBUG
+
+external_components:
+  - source:
+      type: local
+      path: ../../../components
+    components: [MhiAcCtrl]
+
+MhiAcCtrl:
+  id: mhi_ac
+  frame_size: 33
+  sck_pin: 8
+  mosi_pin: 38
+  miso_pin: 39
+  rx_driver: fast_gpio_rx
+  tx_driver: fast_gpio_tx
+  fan_profile: quiet_four_speed
+
+climate:
+  - platform: MhiAcCtrl
+    mhi_ac_ctrl_id: mhi_ac
+    name: MHI Climate Quiet Four Speed
+
+select:
+  - platform: MhiAcCtrl
+    mhi_ac_ctrl_id: mhi_ac
+    fan_speed:
+      name: MHI Fan Speed Quiet Four Speed

--- a/tests/components/MhiAcCtrl/test.esp32-s3-idf-three-speed.yaml
+++ b/tests/components/MhiAcCtrl/test.esp32-s3-idf-three-speed.yaml
@@ -1,6 +1,6 @@
 esphome:
-  name: mhi-redux-compile-quiet-fs
-  friendly_name: MHI Redux Legacy Four Speed Alias Compile Test
+  name: mhi-redux-compile-three-speed
+  friendly_name: MHI Redux Three Speed Compile Test
 
 esp32:
   board: esp32-s3-devkitc-1
@@ -24,15 +24,15 @@ MhiAcCtrl:
   miso_pin: 39
   rx_driver: fast_gpio_rx
   tx_driver: fast_gpio_tx
-  fan_profile: quiet_four_speed
+  fan_profile: three_speed
 
 climate:
   - platform: MhiAcCtrl
     mhi_ac_ctrl_id: mhi_ac
-    name: MHI Climate Legacy Four Speed Alias
+    name: MHI Climate Three Speed
 
 select:
   - platform: MhiAcCtrl
     mhi_ac_ctrl_id: mhi_ac
     fan_speed:
-      name: MHI Fan Speed Legacy Four Speed Alias
+      name: MHI Fan Speed Three Speed

--- a/tests/stubs/esphome/components/climate/climate.h
+++ b/tests/stubs/esphome/components/climate/climate.h
@@ -16,6 +16,7 @@ enum ClimateMode {
 
 enum ClimateFanMode {
   CLIMATE_FAN_AUTO,
+  CLIMATE_FAN_QUIET,
   CLIMATE_FAN_LOW,
   CLIMATE_FAN_MEDIUM,
   CLIMATE_FAN_HIGH,

--- a/tests/unit/mhi_test_common.h
+++ b/tests/unit/mhi_test_common.h
@@ -274,10 +274,10 @@ void fixture_opdata_outdoor_temp_decodes();
 void fixture_opdata_current_decodes();
 
 
-void fan_profile_defaults_to_three_speed();
+void fan_profile_defaults_to_four_speed();
 void fan_profile_three_speed_collapses_code_zero_to_low();
 void fan_profile_four_speed_exposes_code_zero_as_quiet();
-void fan_profile_encodes_quiet_only_when_opted_in();
+void fan_profile_encodes_quiet_only_for_four_speed();
 void status_decoder_preserves_protocol_fan_code_zero();
 void publish_bridge_three_speed_maps_code_zero_to_low();
 void publish_bridge_four_speed_maps_code_zero_to_quiet();

--- a/tests/unit/mhi_test_common.h
+++ b/tests/unit/mhi_test_common.h
@@ -19,6 +19,7 @@
 #include "mhi_frame_catalog.h"
 #include "mhi_frame_classifier.h"
 #include "mhi_frame_sync.h"
+#include "mhi_fan_profile.h"
 #include "mhi_opdata_decoder.h"
 #include "mhi_publish_bridge.h"
 #include "mhi_status_decoder.h"
@@ -240,6 +241,8 @@ void tx_builder_drops_33_byte_only_commands_in_20_byte_mode();
 void tx_builder_applies_3d_auto_in_33_byte_frame();
 void tx_builder_reports_horizontal_vane_intent_in_33_byte_frame();
 void tx_builder_preserves_horizontal_context_for_3d_auto_command();
+void tx_builder_persists_external_room_temperature_override();
+void tx_builder_clears_external_room_temperature_override();
 
 void command_confirmation_confirms_power_mode_and_vertical_vane();
 void command_confirmation_keeps_partial_pending_until_later_status();
@@ -270,7 +273,14 @@ void fixture_garbage_then_valid_frame_resyncs();
 void fixture_opdata_outdoor_temp_decodes();
 void fixture_opdata_current_decodes();
 
-void tx_builder_persists_external_room_temperature_override();
-void tx_builder_clears_external_room_temperature_override();
 
+void fan_profile_defaults_to_three_speed();
+void fan_profile_three_speed_collapses_code_zero_to_low();
+void fan_profile_four_speed_exposes_code_zero_as_quiet();
+void fan_profile_encodes_quiet_only_when_opted_in();
+void status_decoder_preserves_protocol_fan_code_zero();
+void publish_bridge_three_speed_maps_code_zero_to_low();
+void publish_bridge_four_speed_maps_code_zero_to_quiet();
+void tx_builder_encodes_quiet_fan_code_zero();
+void command_confirmation_confirms_quiet_fan_code_zero();
 }  // namespace mhi_unit_tests

--- a/tests/unit/mhi_unit_test_main.cpp
+++ b/tests/unit/mhi_unit_test_main.cpp
@@ -24,10 +24,10 @@ int main() {
   frame_catalog_keeps_command_candidate_side_slot_latest_only();
   frame_catalog_reports_unknown_frames();
 
-  fan_profile_defaults_to_three_speed();
+  fan_profile_defaults_to_four_speed();
   fan_profile_three_speed_collapses_code_zero_to_low();
   fan_profile_four_speed_exposes_code_zero_as_quiet();
-  fan_profile_encodes_quiet_only_when_opted_in();
+  fan_profile_encodes_quiet_only_for_four_speed();
 
   status_decoder_decodes_core_fields();
   status_decoder_preserves_protocol_fan_code_zero();

--- a/tests/unit/mhi_unit_test_main.cpp
+++ b/tests/unit/mhi_unit_test_main.cpp
@@ -24,7 +24,13 @@ int main() {
   frame_catalog_keeps_command_candidate_side_slot_latest_only();
   frame_catalog_reports_unknown_frames();
 
+  fan_profile_defaults_to_three_speed();
+  fan_profile_three_speed_collapses_code_zero_to_low();
+  fan_profile_four_speed_exposes_code_zero_as_quiet();
+  fan_profile_encodes_quiet_only_when_opted_in();
+
   status_decoder_decodes_core_fields();
+  status_decoder_preserves_protocol_fan_code_zero();
   status_decoder_decodes_33_byte_vane_feedback();
   status_decoder_ignores_unknown_horizontal_vane_feedback();
   status_decoder_ignores_33_byte_vane_feedback_on_opdata_frames();
@@ -45,6 +51,8 @@ int main() {
   publish_bridge_publishes_sensor_parity_slice2_on_first_opdata_publish();
   publish_bridge_maps_unknown_protection_state();
   publish_bridge_maps_mhi_auto_to_heat_cool_for_ha_setpoint_ui();
+  publish_bridge_three_speed_maps_code_zero_to_low();
+  publish_bridge_four_speed_maps_code_zero_to_quiet();
   publish_bridge_publishes_sensor_parity_slice3_vane_feedback();
   publish_bridge_suppresses_unchanged_sensor_republishes();
   publish_bridge_suppresses_alternating_climate_current_temperature_chatter();
@@ -57,16 +65,20 @@ int main() {
   tx_builder_uses_configured_sensor_parity_opdata_mask();
   tx_builder_uses_configured_sensor_parity_slice2_opdata_mask();
   tx_builder_reports_encoded_command_mask();
+  tx_builder_encodes_quiet_fan_code_zero();
   tx_builder_keeps_double_frame_commands_pending_until_command_frame();
   tx_builder_drops_33_byte_only_commands_in_20_byte_mode();
   tx_builder_applies_3d_auto_in_33_byte_frame();
   tx_builder_reports_horizontal_vane_intent_in_33_byte_frame();
   tx_builder_preserves_horizontal_context_for_3d_auto_command();
+  tx_builder_persists_external_room_temperature_override();
+  tx_builder_clears_external_room_temperature_override();
 
   command_confirmation_confirms_power_mode_and_vertical_vane();
   command_confirmation_keeps_partial_pending_until_later_status();
   command_confirmation_confirms_auto_fan();
   command_confirmation_confirms_supported_fan_codes();
+  command_confirmation_confirms_quiet_fan_code_zero();
   command_confirmation_times_out_unconfirmed_commands();
   command_confirmation_detects_duplicate_pending_commands();
   command_confirmation_confirms_horizontal_vane_feedback();
@@ -90,9 +102,6 @@ int main() {
   fixture_garbage_then_valid_frame_resyncs();
   fixture_opdata_outdoor_temp_decodes();
   fixture_opdata_current_decodes();
-
-  tx_builder_persists_external_room_temperature_override();
-  tx_builder_clears_external_room_temperature_override();
 
   std::cout << "MHI protocol unit tests passed\n";
   return 0;

--- a/tests/unit/test_command_confirmation.cpp
+++ b/tests/unit/test_command_confirmation.cpp
@@ -85,6 +85,23 @@ void command_confirmation_confirms_supported_fan_codes() {
   EXPECT_FALSE(confirmation.has_pending());
 }
 
+
+void command_confirmation_confirms_quiet_fan_code_zero() {
+  MhiCommandConfirmation confirmation{};
+
+  MhiCommandIntent intent{};
+  intent.mask = MHI_COMMAND_FAN;
+  intent.fan = 0U;
+  confirmation.stage(intent, intent.mask, 1000U);
+
+  MhiStatusState status{};
+  status.valid = true;
+  status.fan = 0U;
+
+  EXPECT_EQ(confirmation.observe_status(status), static_cast<uint32_t>(MHI_COMMAND_FAN));
+  EXPECT_FALSE(confirmation.has_pending());
+}
+
 void command_confirmation_times_out_unconfirmed_commands() {
   MhiCommandConfirmation confirmation{};
 

--- a/tests/unit/test_fan_profile.cpp
+++ b/tests/unit/test_fan_profile.cpp
@@ -2,35 +2,35 @@
 
 namespace mhi_unit_tests {
 
-void fan_profile_defaults_to_three_speed() {
-  EXPECT_EQ(static_cast<uint8_t>(mhi_fan_profile_from_name("three_speed")),
-            static_cast<uint8_t>(MhiFanProfile::THREE_SPEED));
+void fan_profile_defaults_to_four_speed() {
+  EXPECT_EQ(static_cast<uint8_t>(mhi_fan_profile_from_name("four_speed")),
+            static_cast<uint8_t>(MhiFanProfile::FOUR_SPEED));
   EXPECT_EQ(static_cast<uint8_t>(mhi_fan_profile_from_name("unknown")),
-            static_cast<uint8_t>(MhiFanProfile::THREE_SPEED));
-  EXPECT_FALSE(mhi_fan_profile_supports_quiet(MhiFanProfile::THREE_SPEED));
+            static_cast<uint8_t>(MhiFanProfile::FOUR_SPEED));
+  EXPECT_TRUE(mhi_fan_profile_supports_quiet(MhiFanProfile::FOUR_SPEED));
+  EXPECT_TRUE(std::string(mhi_fan_profile_name(MhiFanProfile::FOUR_SPEED)) == "four_speed");
 }
 
 void fan_profile_three_speed_collapses_code_zero_to_low() {
+  EXPECT_EQ(static_cast<uint8_t>(mhi_fan_profile_from_name("three_speed")),
+            static_cast<uint8_t>(MhiFanProfile::THREE_SPEED));
+  EXPECT_FALSE(mhi_fan_profile_supports_quiet(MhiFanProfile::THREE_SPEED));
   EXPECT_EQ(static_cast<uint8_t>(mhi_fan_mode_from_code(MhiFanProfile::THREE_SPEED, 0U)),
             static_cast<uint8_t>(MhiFanMode::LOW));
   EXPECT_TRUE(std::string(mhi_fan_mode_name(mhi_fan_mode_from_code(MhiFanProfile::THREE_SPEED, 0U))) == "Low");
 }
 
 void fan_profile_four_speed_exposes_code_zero_as_quiet() {
-  EXPECT_EQ(static_cast<uint8_t>(mhi_fan_profile_from_name("quiet_four_speed")),
-            static_cast<uint8_t>(MhiFanProfile::QUIET_FOUR_SPEED));
-  EXPECT_TRUE(mhi_fan_profile_supports_quiet(MhiFanProfile::QUIET_FOUR_SPEED));
-  EXPECT_EQ(static_cast<uint8_t>(mhi_fan_mode_from_code(MhiFanProfile::QUIET_FOUR_SPEED, 0U)),
+  EXPECT_EQ(static_cast<uint8_t>(mhi_fan_mode_from_code(MhiFanProfile::FOUR_SPEED, 0U)),
             static_cast<uint8_t>(MhiFanMode::QUIET));
-  EXPECT_TRUE(std::string(mhi_fan_mode_name(mhi_fan_mode_from_code(MhiFanProfile::QUIET_FOUR_SPEED, 0U))) ==
-              "Quiet");
+  EXPECT_TRUE(std::string(mhi_fan_mode_name(mhi_fan_mode_from_code(MhiFanProfile::FOUR_SPEED, 0U))) == "Quiet");
 }
 
-void fan_profile_encodes_quiet_only_when_opted_in() {
+void fan_profile_encodes_quiet_only_for_four_speed() {
   uint8_t code = 0xFFU;
   EXPECT_FALSE(mhi_fan_code_from_mode(MhiFanProfile::THREE_SPEED, MhiFanMode::QUIET, code));
   EXPECT_EQ(code, 0xFFU);
-  EXPECT_TRUE(mhi_fan_code_from_mode(MhiFanProfile::QUIET_FOUR_SPEED, MhiFanMode::QUIET, code));
+  EXPECT_TRUE(mhi_fan_code_from_mode(MhiFanProfile::FOUR_SPEED, MhiFanMode::QUIET, code));
   EXPECT_EQ(code, 0U);
 }
 

--- a/tests/unit/test_fan_profile.cpp
+++ b/tests/unit/test_fan_profile.cpp
@@ -1,0 +1,37 @@
+#include "mhi_test_common.h"
+
+namespace mhi_unit_tests {
+
+void fan_profile_defaults_to_three_speed() {
+  EXPECT_EQ(static_cast<uint8_t>(mhi_fan_profile_from_name("three_speed")),
+            static_cast<uint8_t>(MhiFanProfile::THREE_SPEED));
+  EXPECT_EQ(static_cast<uint8_t>(mhi_fan_profile_from_name("unknown")),
+            static_cast<uint8_t>(MhiFanProfile::THREE_SPEED));
+  EXPECT_FALSE(mhi_fan_profile_supports_quiet(MhiFanProfile::THREE_SPEED));
+}
+
+void fan_profile_three_speed_collapses_code_zero_to_low() {
+  EXPECT_EQ(static_cast<uint8_t>(mhi_fan_mode_from_code(MhiFanProfile::THREE_SPEED, 0U)),
+            static_cast<uint8_t>(MhiFanMode::LOW));
+  EXPECT_TRUE(std::string(mhi_fan_mode_name(mhi_fan_mode_from_code(MhiFanProfile::THREE_SPEED, 0U))) == "Low");
+}
+
+void fan_profile_four_speed_exposes_code_zero_as_quiet() {
+  EXPECT_EQ(static_cast<uint8_t>(mhi_fan_profile_from_name("quiet_four_speed")),
+            static_cast<uint8_t>(MhiFanProfile::QUIET_FOUR_SPEED));
+  EXPECT_TRUE(mhi_fan_profile_supports_quiet(MhiFanProfile::QUIET_FOUR_SPEED));
+  EXPECT_EQ(static_cast<uint8_t>(mhi_fan_mode_from_code(MhiFanProfile::QUIET_FOUR_SPEED, 0U)),
+            static_cast<uint8_t>(MhiFanMode::QUIET));
+  EXPECT_TRUE(std::string(mhi_fan_mode_name(mhi_fan_mode_from_code(MhiFanProfile::QUIET_FOUR_SPEED, 0U))) ==
+              "Quiet");
+}
+
+void fan_profile_encodes_quiet_only_when_opted_in() {
+  uint8_t code = 0xFFU;
+  EXPECT_FALSE(mhi_fan_code_from_mode(MhiFanProfile::THREE_SPEED, MhiFanMode::QUIET, code));
+  EXPECT_EQ(code, 0xFFU);
+  EXPECT_TRUE(mhi_fan_code_from_mode(MhiFanProfile::QUIET_FOUR_SPEED, MhiFanMode::QUIET, code));
+  EXPECT_EQ(code, 0U);
+}
+
+}  // namespace mhi_unit_tests

--- a/tests/unit/test_publish_bridge.cpp
+++ b/tests/unit/test_publish_bridge.cpp
@@ -488,3 +488,52 @@ void publish_bridge_publishes_high_priority_climate_current_temperature_change_i
 
 
 }  // namespace mhi_unit_tests
+
+
+namespace mhi_unit_tests {
+
+void publish_bridge_three_speed_maps_code_zero_to_low() {
+  MhiStateStore state{};
+  auto& status = state.status();
+  status.valid = true;
+  status.fan = 0U;
+
+  esphome::climate::Climate climate{};
+  esphome::select::Select fan{};
+  MhiPublishTargets targets{};
+  targets.climate = &climate;
+  targets.fan_speed_select = &fan;
+
+  MhiPublishBridge bridge{};
+  bridge.set_fan_profile(MhiFanProfile::THREE_SPEED);
+  bridge.set_targets(targets);
+  bridge.publish(state);
+
+  EXPECT_TRUE(climate.fan_mode.has_value());
+  EXPECT_EQ(climate.fan_mode.value(), esphome::climate::CLIMATE_FAN_LOW);
+  EXPECT_TRUE(fan.state == "Low");
+}
+
+void publish_bridge_four_speed_maps_code_zero_to_quiet() {
+  MhiStateStore state{};
+  auto& status = state.status();
+  status.valid = true;
+  status.fan = 0U;
+
+  esphome::climate::Climate climate{};
+  esphome::select::Select fan{};
+  MhiPublishTargets targets{};
+  targets.climate = &climate;
+  targets.fan_speed_select = &fan;
+
+  MhiPublishBridge bridge{};
+  bridge.set_fan_profile(MhiFanProfile::QUIET_FOUR_SPEED);
+  bridge.set_targets(targets);
+  bridge.publish(state);
+
+  EXPECT_TRUE(climate.fan_mode.has_value());
+  EXPECT_EQ(climate.fan_mode.value(), esphome::climate::CLIMATE_FAN_QUIET);
+  EXPECT_TRUE(fan.state == "Quiet");
+}
+
+}  // namespace mhi_unit_tests

--- a/tests/unit/test_publish_bridge.cpp
+++ b/tests/unit/test_publish_bridge.cpp
@@ -527,7 +527,7 @@ void publish_bridge_four_speed_maps_code_zero_to_quiet() {
   targets.fan_speed_select = &fan;
 
   MhiPublishBridge bridge{};
-  bridge.set_fan_profile(MhiFanProfile::QUIET_FOUR_SPEED);
+  bridge.set_fan_profile(MhiFanProfile::FOUR_SPEED);
   bridge.set_targets(targets);
   bridge.publish(state);
 

--- a/tests/unit/test_status_decoder.cpp
+++ b/tests/unit/test_status_decoder.cpp
@@ -19,6 +19,17 @@ void status_decoder_decodes_core_fields() {
 }
 
 
+
+void status_decoder_preserves_protocol_fan_code_zero() {
+  MhiFrameBuffer frame = make_mosi_status_frame();
+  frame.data[DB1] = static_cast<uint8_t>(frame.data[DB1] & 0xF8U);
+
+  MhiDecodedStatus decoded{};
+  EXPECT_TRUE(MhiStatusDecoder::decode_mosi(frame.view(), decoded));
+  EXPECT_EQ(decoded.fan_raw, 0U);
+  EXPECT_EQ(decoded.fan, 0U);
+}
+
 void status_decoder_decodes_33_byte_vane_feedback() {
   const MhiFrameBuffer frame = make_mosi_status_frame_33(6U, false, true);
 

--- a/tests/unit/test_tx_builder.cpp
+++ b/tests/unit/test_tx_builder.cpp
@@ -113,6 +113,24 @@ void tx_builder_reports_encoded_command_mask() {
   EXPECT_FALSE(command.has_pending_command());
 }
 
+
+void tx_builder_encodes_quiet_fan_code_zero() {
+  MhiCommandState command{};
+  command.fan_set = true;
+  command.fan = 0U;
+
+  MhiTxRuntime runtime{};
+  MhiTxBuildConfig config{};
+  MhiFrameBuffer out{};
+  MhiTxBuildResult result{};
+
+  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, out, result));
+  EXPECT_EQ(out.data[DB1] & 0x0FU, 0x08U);
+  EXPECT_EQ(result.encoded_command_mask, static_cast<uint32_t>(MHI_COMMAND_FAN));
+  EXPECT_EQ(result.intent.fan, 0U);
+  EXPECT_TRUE(mhi_checksum_valid_20(out.data));
+}
+
 void tx_builder_keeps_double_frame_commands_pending_until_command_frame() {
   MhiCommandState command{};
   command.fan_set = true;
@@ -233,37 +251,43 @@ void tx_builder_preserves_horizontal_context_for_3d_auto_command() {
   EXPECT_FALSE(command.has_pending_command());
 }
 
+
+
 void tx_builder_persists_external_room_temperature_override() {
   MhiCommandState command{};
+  command.room_temp_override_set = true;
+  command.room_temp_override_raw = 0x9DU;  // 24.0C: (24 * 4) + 61.
+
   MhiTxRuntime runtime{};
   MhiTxBuildConfig config{};
-  MhiFrameBuffer first{};
-  MhiFrameBuffer second{};
+  MhiFrameBuffer out{};
+  MhiTxBuildResult result{};
 
-  config.frame_size = kMhiFrame20Bytes;
-  runtime.room_temp_override_raw = 0x89U;
+  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, out, result));
+  EXPECT_EQ(out.data[DB3], 0x9DU);
+  EXPECT_EQ(result.encoded_command_mask, static_cast<uint32_t>(MHI_COMMAND_ROOM_TEMP_OVERRIDE));
+  EXPECT_FALSE(command.room_temp_override_set);
 
-  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, first));
-  EXPECT_EQ(first.data[DB3], 0x89U);
-
-  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, second));
-  EXPECT_EQ(second.data[DB3], 0x89U);
+  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, out, result));
+  EXPECT_EQ(out.data[DB3], 0x9DU);
+  EXPECT_EQ(result.encoded_command_mask, 0U);
 }
 
 void tx_builder_clears_external_room_temperature_override() {
   MhiCommandState command{};
   MhiTxRuntime runtime{};
+  runtime.room_temp_override_raw = 0x9DU;
   MhiTxBuildConfig config{};
-  MhiFrameBuffer frame{};
+  MhiFrameBuffer out{};
+  MhiTxBuildResult result{};
 
-  config.frame_size = kMhiFrame33Bytes;
-  runtime.room_temp_override_raw = 0x91U;
-  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, frame));
-  EXPECT_EQ(frame.data[DB3], 0x91U);
+  command.room_temp_override_set = true;
+  command.room_temp_override_raw = 0xFFU;
 
-  runtime.room_temp_override_raw = 0xFFU;
-  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, frame));
-  EXPECT_EQ(frame.data[DB3], 0xFFU);
+  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, out, result));
+  EXPECT_EQ(out.data[DB3], 0xFFU);
+  EXPECT_EQ(runtime.room_temp_override_raw, 0xFFU);
+  EXPECT_EQ(result.encoded_command_mask, static_cast<uint32_t>(MHI_COMMAND_ROOM_TEMP_OVERRIDE));
 }
 
 }  // namespace mhi_unit_tests


### PR DESCRIPTION
I’ve updated the fan-profile handling so four fixed fan speeds are now the default.

No additional configuration is required:

```yaml
MhiAcCtrl:
  # fan_profile defaults to four_speed
```

This exposes:

* Quiet
* Low
* Medium
* High
* Auto

For units that should only expose three fixed speeds, this can be explicitly configured:

```yaml
MhiAcCtrl:
  fan_profile: three_speed
```

The four-speed profile has now been tested on both of my AC units, including the unit that initially appeared to support only three fixed speeds.

Hardware testing confirmed that:

* Quiet and Low use different protocol values;
* each fan mode is confirmed correctly from the returned AC status;
* the climate entity and fan-speed select remain in sync;
* Quiet, Low, Medium, High and Auto can all be selected successfully;
* no fan command failures or confirmation timeouts were observed.

Unit tests and ESPHome compile tests also pass with `four_speed` as the default and `three_speed` retained as an explicit compatibility option.

Configurable options:
```yaml
MhiAcCtrl:
  fan_profile: three_speed
  fan_profile: four_speed  #  This is the default but can be explicitly used.
```

