### PR TITLE
Fix 3D-auto write: always assert louver command-indicator bits in DB17

### DIFF
--- a/components/MhiAcCtrl/mhi_tx_builder.cpp
+++ b/components/MhiAcCtrl/mhi_tx_builder.cpp
@@ -280,9 +280,11 @@ void MhiTxBuilder::apply_commands(MhiFrameBuffer& out, MhiCommandState& command,
 
       out.data[DB17] = static_cast<uint8_t>((out.data[DB17] & ~0x04U) | (command.three_d_auto ? 0x04U : 0x00U));
 
-      if ((out.data[DB17] & 0x0BU) == 0U) {
-        out.data[DB17] |= 0x0AU;
-      }
+      // Louver command-indicator bits (0x08 | 0x02) must be asserted for the
+      // AC to accept the write. The previous conditional skipped this when
+      // bit 0x01 was carried over from the preserved louver state, leaving
+      // DB17 as 0x05 which the AC treats as a status echo, not a command.
+      out.data[DB17] |= 0x0AU;
 
       result.intent.three_d_auto = command.three_d_auto;
       command.three_d_auto_set = false;


### PR DESCRIPTION
## Summary

3D-auto ON/OFF writes on 33-byte frames were emitted without the louver
command-indicator bits (0x08 | 0x02) whenever the preserved-louver branch
had copied bit 0x01 (horizontal swing) into DB17 from the live status.
The AC interpreted those frames as status echoes rather than commands, so
the write took no effect on the unit while the confirmation tracker timed
out after the fact.

The existing guard was:

```cpp
if ((out.data[DB17] & 0x0BU) == 0U) {
  out.data[DB17] |= 0x0AU;
}
```

Once bit 0x01 was carried over from the preserved state the guard passed
without adding 0x0A, so a 3D-auto ON went out as `db17=0x05` instead of
`0x0E`. Asserting 0x0A unconditionally is safe: the state bits stay put
and the resulting pattern matches what `horizontal_vane` writes already
use (`0x0A` for fixed positions, `0x0B` for swing).

## DB17 bit layout used here

| Bit  | Meaning                                       |
| ---- | --------------------------------------------- |
| 0x01 | horizontal swing (state)                      |
| 0x02 | louver command indicator                      |
| 0x04 | 3D-auto (state)                               |
| 0x08 | command indicator                             |

Horizontal-vane writes already set `0x08 | 0x02` (plus 0x01 for swing) to
signal "this is a command." 3D-auto writes need the same pair.

## Verification

Tested on SRK50ZT-WF (33-byte protocol).

**Before** — 3D-auto ON, staged frame followed by a confirmation timeout,
no state change on the unit:

```
command: staged=YES mask=0x00000040 len=33 ... db16=0x00 db17=0x05
[W] command: confirmation timeout mask=0x00000040
```

**After** — 3D-auto ON, then OFF, both confirmed within a second, unit
state flipped:

```
# ON
command: staged=YES mask=0x00000040 len=33 ... db16=0x14 db17=0x0e
command: confirmed mask=0x00000040 pending=0x00000000
'3D Auto Active' >> ON

# OFF
command: staged=YES mask=0x00000040 len=33 ... db16=0x14 db17=0x0a
command: confirmed mask=0x00000040 pending=0x00000000
'3D Auto Active' >> OFF
```

`command_confirmation_timeouts` did not increment across the toggles.