### PR TITLE
fix(MhiFrameCatalog): enhance opdata slot management and increase cap…

### DIFF
--- a/components/MhiAcCtrl/mhi_frame_catalog.cpp
+++ b/components/MhiAcCtrl/mhi_frame_catalog.cpp
@@ -157,19 +157,26 @@ void MhiFrameCatalog::copy_slot_(const MhiCatalogSlot& slot, MhiCatalogedFrame& 
 }
 
 MhiCatalogSlot* MhiFrameCatalog::find_or_allocate_opdata_slot_(uint16_t opdata_key) {
-  MhiCatalogSlot* empty = nullptr;
+  MhiCatalogSlot* reusable = nullptr;
 
   for (auto& slot : opdata_slots_) {
     if (slot.kind == MhiFrameKind::OPDATA && slot.opdata_key == opdata_key) {
       return &slot;
     }
 
-    if (empty == nullptr && slot.writes == 0U && !slot.valid) {
-      empty = &slot;
+    // A consumed slot is reusable even if it previously held a different key.
+    // The old implementation required writes == 0, permanently exhausting the
+    // catalogue after enough distinct opdata keys had been observed.
+    if (reusable == nullptr && !slot.valid) {
+      reusable = &slot;
     }
   }
 
-  return empty;
+  if (reusable != nullptr) {
+    *reusable = {};
+  }
+
+  return reusable;
 }
 
 MhiCatalogIngestResult MhiFrameCatalog::write_slot_(MhiCatalogSlot& slot, const MhiFrameView& frame, MhiFrameKind kind,

--- a/components/MhiAcCtrl/mhi_frame_catalog.h
+++ b/components/MhiAcCtrl/mhi_frame_catalog.h
@@ -9,7 +9,7 @@
 namespace esphome {
 namespace mhi_ac_ctrl {
 
-constexpr std::size_t kMhiCatalogOpDataSlots = 16U;
+constexpr std::size_t kMhiCatalogOpDataSlots = 32U;
 
 struct MhiCatalogStats {
   uint32_t ingested_frames{0};

--- a/components/MhiAcCtrl/mhi_frame_classifier.cpp
+++ b/components/MhiAcCtrl/mhi_frame_classifier.cpp
@@ -33,8 +33,14 @@ bool opdata_marker_present(const MhiFrameView& frame) {
 }
 
 uint16_t opdata_key(const MhiFrameView& frame) {
-  const uint16_t bank = (frame[DB6] & 0x80U) != 0U ? 0x8000U : 0x0000U;
-  return static_cast<uint16_t>(bank | (static_cast<uint16_t>(frame[DB9]) << 8U) | frame[DB10]);
+  // The response bank plus DB9 identifies the requested opdata field. DB10
+  // contains response-type and, for several fields, live value bits, so it must
+  // not participate in the catalogue key.
+  //
+  // Keep the bank in bit 8 and DB9 in bits 0..7. Using bit 15 for the bank would
+  // collide with DB9 groups >= 0x80 after shifting.
+  const uint16_t bank = (frame[DB6] & 0x80U) != 0U ? 0x0100U : 0x0000U;
+  return static_cast<uint16_t>(bank | frame[DB9]);
 }
 
 }  // namespace

--- a/tests/unit/mhi_test_common.h
+++ b/tests/unit/mhi_test_common.h
@@ -203,8 +203,12 @@ void duplex_tx_mailbox_latest_stage_replaces_unclaimed_frame();
 void duplex_tx_mailbox_rejects_invalid_frames_without_losing_pending_data();
 
 void frame_classifier_classifies_status_opdata_and_extended_status();
+void frame_classifier_uses_stable_opdata_keys_when_value_bits_change();
 void frame_catalog_overwrites_repeated_status_with_latest();
 void frame_catalog_keeps_opdata_slots_separate_by_key();
+void frame_catalog_overwrites_changing_values_for_same_opdata_field();
+void frame_catalog_reuses_consumed_opdata_slots();
+void frame_catalog_buffers_all_supported_opdata_groups();
 void frame_catalog_keeps_command_candidate_side_slot_latest_only();
 void frame_catalog_reports_unknown_frames();
 

--- a/tests/unit/mhi_unit_test_main.cpp
+++ b/tests/unit/mhi_unit_test_main.cpp
@@ -23,8 +23,12 @@ int main() {
   duplex_tx_mailbox_rejects_invalid_frames_without_losing_pending_data();
 
   frame_classifier_classifies_status_opdata_and_extended_status();
+  frame_classifier_uses_stable_opdata_keys_when_value_bits_change();
   frame_catalog_overwrites_repeated_status_with_latest();
   frame_catalog_keeps_opdata_slots_separate_by_key();
+  frame_catalog_overwrites_changing_values_for_same_opdata_field();
+  frame_catalog_reuses_consumed_opdata_slots();
+  frame_catalog_buffers_all_supported_opdata_groups();
   frame_catalog_keeps_command_candidate_side_slot_latest_only();
   frame_catalog_reports_unknown_frames();
 

--- a/tests/unit/test_frame_catalog.cpp
+++ b/tests/unit/test_frame_catalog.cpp
@@ -16,7 +16,7 @@ void frame_classifier_classifies_status_opdata_and_extended_status() {
   const MhiFrameBuffer opdata = make_legacy_opdata_frame(0x00, 0x80, 0x10, 202);
   const MhiFrameClassification opdata_classification = classify_mhi_mosi_frame(opdata.view());
   EXPECT_EQ(static_cast<int>(opdata_classification.kind), static_cast<int>(MhiFrameKind::OPDATA));
-  EXPECT_EQ(opdata_classification.opdata_key, 0x8010U);
+  EXPECT_EQ(opdata_classification.opdata_key, 0x0080U);
 
   const MhiFrameBuffer extended = make_mosi_status_frame_33(2U, false, false);
   const MhiFrameClassification extended_classification = classify_mhi_mosi_frame(extended.view());
@@ -48,7 +48,31 @@ void frame_classifier_classifies_status_opdata_and_extended_status() {
   const MhiFrameClassification high_db6_response_marker_classification =
       classify_mhi_mosi_frame(high_db6_response_marker.view());
   EXPECT_EQ(static_cast<int>(high_db6_response_marker_classification.kind), static_cast<int>(MhiFrameKind::OPDATA));
-  EXPECT_EQ(high_db6_response_marker_classification.opdata_key, 0x9E10U);
+  EXPECT_EQ(high_db6_response_marker_classification.opdata_key, 0x011EU);
+}
+
+void frame_classifier_uses_stable_opdata_keys_when_value_bits_change() {
+  const MhiFrameBuffer fan_stopped = make_legacy_opdata_frame(0x00, 0x1F, 0x10, 0x00);
+  const MhiFrameBuffer fan_running = make_legacy_opdata_frame(0x00, 0x1F, 0x14, 0x00);
+  const MhiFrameBuffer compressor_low = make_legacy_opdata_frame(0x00, 0x11, 0x10, 0x20);
+  const MhiFrameBuffer compressor_high = make_legacy_opdata_frame(0x00, 0x11, 0x19, 0x40);
+  const MhiFrameBuffer return_air = make_legacy_opdata_frame(0x80, 0x80, 0x20, 0x80);
+  const MhiFrameBuffer outdoor_air = make_legacy_opdata_frame(0x00, 0x80, 0x10, 0x80);
+
+  const auto stopped = classify_mhi_mosi_frame(fan_stopped.view());
+  const auto running = classify_mhi_mosi_frame(fan_running.view());
+  const auto low = classify_mhi_mosi_frame(compressor_low.view());
+  const auto high = classify_mhi_mosi_frame(compressor_high.view());
+  const auto indoor = classify_mhi_mosi_frame(return_air.view());
+  const auto outdoor = classify_mhi_mosi_frame(outdoor_air.view());
+
+  EXPECT_EQ(stopped.opdata_key, running.opdata_key);
+  EXPECT_EQ(stopped.opdata_key, 0x001FU);
+  EXPECT_EQ(low.opdata_key, high.opdata_key);
+  EXPECT_EQ(low.opdata_key, 0x0011U);
+  EXPECT_TRUE(indoor.opdata_key != outdoor.opdata_key);
+  EXPECT_EQ(indoor.opdata_key, 0x0180U);
+  EXPECT_EQ(outdoor.opdata_key, 0x0080U);
 }
 
 void frame_catalog_overwrites_repeated_status_with_latest() {
@@ -140,6 +164,81 @@ void frame_catalog_keeps_opdata_slots_separate_by_key() {
   EXPECT_TRUE(catalog.take_latest_opdata(second.opdata_key, latest_return_air));
   EXPECT_EQ(latest_return_air.sequence, 2U);
   EXPECT_EQ(latest_return_air.frame.data[DB11], 168U);
+}
+
+void frame_catalog_overwrites_changing_values_for_same_opdata_field() {
+  MhiFrameCatalog catalog{};
+
+  const MhiFrameBuffer stopped = make_legacy_opdata_frame(0x00, 0x1F, 0x10, 0x00);
+  const MhiFrameBuffer running = make_legacy_opdata_frame(0x00, 0x1F, 0x14, 0x00);
+
+  const auto first = catalog.ingest_mosi_frame(stopped.view(), 1U, 1000U);
+  const auto second = catalog.ingest_mosi_frame(running.view(), 2U, 1010U);
+
+  EXPECT_TRUE(first.stored);
+  EXPECT_TRUE(second.stored);
+  EXPECT_TRUE(second.overwritten);
+  EXPECT_EQ(first.opdata_key, second.opdata_key);
+  EXPECT_EQ(catalog.stats().overwritten_frames, 1U);
+  EXPECT_EQ(catalog.stats().dropped_opdata_slots_full, 0U);
+
+  MhiCatalogedFrame latest{};
+  EXPECT_TRUE(catalog.take_latest_opdata(first.opdata_key, latest));
+  EXPECT_EQ(latest.sequence, 2U);
+  EXPECT_EQ(latest.frame.data[DB10], 0x14U);
+}
+
+void frame_catalog_reuses_consumed_opdata_slots() {
+  MhiFrameCatalog catalog{};
+
+  for (std::size_t i = 0; i < kMhiCatalogOpDataSlots; i++) {
+    const uint8_t group = static_cast<uint8_t>(i + 1U);
+    const MhiFrameBuffer frame = make_legacy_opdata_frame(0x00, group, 0x10, static_cast<uint8_t>(i));
+    const auto result = catalog.ingest_mosi_frame(frame.view(), static_cast<uint32_t>(i + 1U), 1000U);
+    EXPECT_TRUE(result.stored);
+  }
+
+  MhiCatalogedFrame consumed{};
+  std::size_t consumed_count = 0U;
+  while (catalog.take_next_opdata(consumed)) {
+    consumed_count++;
+  }
+  EXPECT_EQ(consumed_count, kMhiCatalogOpDataSlots);
+
+  for (std::size_t i = 0; i < kMhiCatalogOpDataSlots; i++) {
+    const uint8_t group = static_cast<uint8_t>(i + kMhiCatalogOpDataSlots + 1U);
+    const MhiFrameBuffer frame = make_legacy_opdata_frame(0x00, group, 0x10, static_cast<uint8_t>(i));
+    const auto result = catalog.ingest_mosi_frame(frame.view(), static_cast<uint32_t>(100U + i), 2000U);
+    EXPECT_TRUE(result.stored);
+  }
+
+  EXPECT_EQ(catalog.stats().dropped_opdata_slots_full, 0U);
+}
+
+void frame_catalog_buffers_all_supported_opdata_groups() {
+  struct OpdataIdentity {
+    uint8_t db6;
+    uint8_t group;
+  };
+
+  constexpr OpdataIdentity identities[] = {
+      {0x80U, 0x02U}, {0x80U, 0x05U}, {0x80U, 0x80U}, {0x80U, 0x81U}, {0x00U, 0x81U},
+      {0x80U, 0x87U}, {0x80U, 0x1FU}, {0x80U, 0x1EU}, {0x00U, 0x80U}, {0x00U, 0x82U},
+      {0x00U, 0x11U}, {0x00U, 0x85U}, {0x00U, 0x90U}, {0x00U, 0xB1U}, {0x00U, 0x7CU},
+      {0x00U, 0x1FU}, {0x00U, 0x0CU}, {0x00U, 0x1EU}, {0x00U, 0x13U}, {0x80U, 0x94U},
+  };
+
+  MhiFrameCatalog catalog{};
+  uint32_t sequence = 1U;
+  for (const auto& identity : identities) {
+    const uint8_t item = identity.db6 == 0x80U ? 0x20U : 0x10U;
+    const MhiFrameBuffer frame = make_legacy_opdata_frame(identity.db6, identity.group, item, 0x01U);
+    const auto result = catalog.ingest_mosi_frame(frame.view(), sequence++, 1000U);
+    EXPECT_TRUE(result.stored);
+  }
+
+  EXPECT_EQ(catalog.stats().opdata_frames, static_cast<uint32_t>(sizeof(identities) / sizeof(identities[0])));
+  EXPECT_EQ(catalog.stats().dropped_opdata_slots_full, 0U);
 }
 
 void frame_catalog_reports_unknown_frames() {


### PR DESCRIPTION
This fixes an issue where some outdoor-unit opdata sensors could stop updating, including:

- Outdoor unit fan speed
- Outdoor unit expansion valve
- Compressor frequency

The issue was introduced when opdata handling was changed from a FIFO queue to a latest-value catalogue.

I originally allocated 16 catalogue slots without checking that against the full number of supported opdata responses. The catalogue key also included DB10, which contains changing data for some responses. As those values changed, they could be treated as new catalogue entries until the available slots were exhausted.

**This change:**

- increases the opdata catalogue from 16 to 32 slots;
- uses the stable response bank and DB9 as the opdata identity;
- excludes changing DB10 value data from the key;
- allows consumed catalogue slots to be reused;
- adds regression tests for fan speed, compressor frequency, response-bank separation and catalogue reuse.

The reported hardware issue has been retested by the affected user, who confirmed that this fix resolved the sensor update problem.

**Validation**

- Native unit tests pass
- Driver-selection tests pass
- AddressSanitizer and UndefinedBehaviourSanitizer tests pass
- Hardware confirmation received from the original reporter