### PR TITLE
ci: run native tests with ASAN and UBSAN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,32 @@ jobs:
       - name: Run unit tests
         run: ./scripts/test.sh
 
+  sanitizers:
+    name: sanitizers
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes g++
+
+      - name: Run ASAN and UBSAN
+        env:
+          SANITIZERS: "1"
+          ASAN_OPTIONS: "detect_leaks=1:halt_on_error=1"
+          UBSAN_OPTIONS: "halt_on_error=1:print_stacktrace=1"
+        run: ./scripts/test.sh
+
   esphome-tests:
     name: esphome-tests
     runs-on: ubuntu-latest

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -11,11 +11,24 @@ mkdir -p "${BUILD_DIR}"
 
 CXX="${CXX:-g++}"
 
+SANITIZER_FLAGS=()
+
+if [[ "${SANITIZERS:-0}" == "1" ]]; then
+  SANITIZER_FLAGS=(
+    -O1
+    -g
+    -fno-omit-frame-pointer
+    -fsanitize=address,undefined
+    -fno-sanitize-recover=all
+  )
+fi
+
 "${CXX}" \
   -std=c++17 \
   -Wall \
   -Wextra \
   -Werror \
+  "${SANITIZER_FLAGS[@]}" \
   -Itests/stubs \
   -Icomponents/MhiAcCtrl \
   tests/unit/mhi_unit_test_main.cpp \


### PR DESCRIPTION
This adds an additional CI job that runs the native C++ unit tests with AddressSanitizer and UndefinedBehaviorSanitizer enabled.

The sanitizer job is intended to catch issues that may not be detected by normal compilation or unit-test assertions, including:

- out-of-bounds memory access;
- use-after-free and invalid pointer access;
- invalid shifts and arithmetic operations;
- misaligned access;
- other undefined C++ behaviour.

**Changes**
- Adds optional sanitizer flags to `scripts/test.sh`.
- Adds a dedicated `sanitizers` job to the GitHub Actions workflow.
- Runs the existing native test suite with:
`-fsanitize=address,undefined
-fno-omit-frame-pointer
-fno-sanitize-recover=all`

The normal unit-test command remains unchanged:
```BASH
./scripts/test.sh
```

Sanitizers can be run locally with:
```BASH
SANITIZERS=1 \
ASAN_OPTIONS="detect_leaks=1:halt_on_error=1" \
UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" \
./scripts/test.sh
```


**Scope**
This instruments the native C++ unit-test build only. It does not instrument the ESP32 firmware or replace:
- ESPHome compile tests;
- hardware soak testing;
- SPI timing validation;
- worker and transport runtime testing.

**Validation**
- Normal native unit tests pass.
- ASAN/UBSAN native tests pass locally.
- The new GitHub Actions sanitizer job passes.