### PR TITLE
Preserve composite louver state and supersede stale confirmations

### DIFF
--- a/components/MhiAcCtrl/mhi_ac_ctrl.cpp
+++ b/components/MhiAcCtrl/mhi_ac_ctrl.cpp
@@ -1719,22 +1719,6 @@ bool MhiAcCtrl::extended_feedback_matches_pending_(const MhiDecodedStatus& decod
     if (!decoded_status.has_3d_auto || decoded_status.three_d_auto != intent.three_d_auto) {
       return false;
     }
-
-    if (intent.has_extended_louver_context) {
-      if (!decoded_status.has_horizontal_vane) {
-        return false;
-      }
-
-      if (intent.horizontal_vane == 8U) {
-        if (!decoded_status.horizontal_swing) {
-          return false;
-        }
-      } else if (intent.horizontal_vane >= 1U && intent.horizontal_vane <= 7U) {
-        if (decoded_status.horizontal_swing || decoded_status.horizontal_vane != intent.horizontal_vane) {
-          return false;
-        }
-      }
-    }
   }
 
   return (pending_mask & kNoPendingExtendedFeedbackMask) != 0U;

--- a/components/MhiAcCtrl/mhi_command_confirmation.h
+++ b/components/MhiAcCtrl/mhi_command_confirmation.h
@@ -10,7 +10,8 @@ namespace esphome {
 namespace mhi_ac_ctrl {
 
 constexpr uint32_t kMhiCommandConfirmationTimeoutMs = 10000U;
-constexpr uint32_t kMhiExtendedLouverConfirmationTimeoutMs = 20000U;
+constexpr uint32_t kMhiExtendedLouverConfirmationTimeoutMs = 3000U;
+constexpr uint32_t kMhiThreeDAutoConfirmationTimeoutMs = 3000U;
 constexpr uint32_t kMhiExtendedLouverSettleDelayMs = 3000U;
 
 struct MhiCommandExpiration {
@@ -76,19 +77,15 @@ class MhiCommandConfirmation {
       }
     }
 
-    if ((this->pending_mask_ & MHI_COMMAND_HORIZONTAL_VANE) != 0U && status.has_horizontal_vane) {
-      if (this->pending_intent_.horizontal_vane == 8U && status.horizontal_vane_swing) {
-        confirmed |= MHI_COMMAND_HORIZONTAL_VANE;
-      } else if (this->pending_intent_.horizontal_vane >= 1U && this->pending_intent_.horizontal_vane <= 7U &&
-                 !status.horizontal_vane_swing && status.horizontal_vane == this->pending_intent_.horizontal_vane) {
-        confirmed |= MHI_COMMAND_HORIZONTAL_VANE;
-      }
+    if ((this->pending_mask_ & MHI_COMMAND_HORIZONTAL_VANE) != 0U &&
+        horizontal_matches_(status, this->pending_intent_.horizontal_vane) &&
+        companion_three_d_matches_(status, this->pending_intent_)) {
+      confirmed |= MHI_COMMAND_HORIZONTAL_VANE;
     }
 
-    // 3D Auto can legitimately change the horizontal-louver context as part of
-    // the command. Confirm it from the decoded 3D Auto feedback bit itself;
-    // requiring the pre-command louver context caused accepted commands to
-    // remain pending until timeout.
+    // 3D Auto is an independent DB17 bit (0x04). A 3D-only command must
+    // confirm from that bit alone; horizontal position/swing is preserved
+    // context, not part of the requested semantic state.
     if ((this->pending_mask_ & MHI_COMMAND_THREE_D_AUTO) != 0U && status.has_3d_auto &&
         status.three_d_auto == this->pending_intent_.three_d_auto) {
       confirmed |= MHI_COMMAND_THREE_D_AUTO;
@@ -159,9 +156,12 @@ class MhiCommandConfirmation {
       return expiration;
     }
 
-    const uint32_t timeout_ms = (this->pending_mask_ & (MHI_COMMAND_HORIZONTAL_VANE | MHI_COMMAND_THREE_D_AUTO)) != 0U
-                                    ? kMhiExtendedLouverConfirmationTimeoutMs
-                                    : kMhiCommandConfirmationTimeoutMs;
+    uint32_t timeout_ms = kMhiCommandConfirmationTimeoutMs;
+    if ((this->pending_mask_ & MHI_COMMAND_THREE_D_AUTO) != 0U) {
+      timeout_ms = kMhiThreeDAutoConfirmationTimeoutMs;
+    } else if ((this->pending_mask_ & MHI_COMMAND_HORIZONTAL_VANE) != 0U) {
+      timeout_ms = kMhiExtendedLouverConfirmationTimeoutMs;
+    }
 
     if ((now_ms - this->staged_ms_) < timeout_ms) {
       return expiration;
@@ -230,6 +230,24 @@ class MhiCommandConfirmation {
   }
 
  private:
+  static bool horizontal_matches_(const MhiStatusState& status, uint8_t expected_horizontal_vane) {
+    if (!status.has_horizontal_vane) {
+      return false;
+    }
+    if (expected_horizontal_vane == 8U) {
+      return status.horizontal_vane_swing;
+    }
+    return expected_horizontal_vane >= 1U && expected_horizontal_vane <= 7U && !status.horizontal_vane_swing &&
+           status.horizontal_vane == expected_horizontal_vane;
+  }
+
+  static bool companion_three_d_matches_(const MhiStatusState& status, const MhiCommandIntent& intent) {
+    if (!intent.has_extended_louver_context || !status.has_3d_auto) {
+      return true;
+    }
+    return status.three_d_auto == intent.three_d_auto;
+  }
+
   void clear_pending_mask_(uint32_t mask) {
     if (mask == 0U) {
       return;

--- a/components/MhiAcCtrl/mhi_command_coordinator.cpp
+++ b/components/MhiAcCtrl/mhi_command_coordinator.cpp
@@ -11,6 +11,8 @@ void MhiCommandCoordinator::reset() {
   in_flight_command_before_build_ = {};
   in_flight_staged_ms_ = 0U;
   staged_timeout_reported_ = false;
+  coalesced_extended_patch_ = {};
+  coalesced_extended_patch_pending_ = false;
   this->reset_attempts_();
 }
 
@@ -20,6 +22,8 @@ bool MhiCommandCoordinator::prepare_next(MhiCommandState& command, MhiTxRuntime&
   if (command_in_flight_ || confirmation_.has_pending()) {
     return false;
   }
+
+  this->apply_coalesced_extended_patch_(command);
 
   if (!MhiTxBuilder::build_next_frame(command, runtime, config, frame, result) || frame.len == 0U) {
     return false;
@@ -51,6 +55,10 @@ void MhiCommandCoordinator::on_stage_result(const MhiTxEnvelope& envelope, const
 
   if (!staged) {
     restore_command_mask_(command, command_before_build, envelope.command_mask);
+    // A coalesced companion field may have been injected inside prepare_next()
+    // after command_before_build was captured. Restore from the encoded intent
+    // as a fallback so a queue failure cannot discard the latest composite target.
+    restore_intent_mask_(command, envelope.intent, envelope.command_mask);
     return;
   }
 
@@ -66,7 +74,6 @@ bool MhiCommandCoordinator::on_tx_completion(const MhiTxCompletion& completion, 
   if (!completion.is_command()) {
     return false;
   }
-
   if (!command_in_flight_ || completion.generation != in_flight_envelope_.generation) {
     return false;
   }
@@ -74,8 +81,14 @@ bool MhiCommandCoordinator::on_tx_completion(const MhiTxCompletion& completion, 
   if (completion.success) {
     uint32_t confirm_mask = in_flight_envelope_.command_mask;
 
-    // If a newer request for the same field arrived while this frame was in
-    // flight, do not let feedback for the old value block the newer command.
+    // A horizontal and 3D request share DB16/DB17. If a request for either
+    // field arrived while this frame was in flight and changes the transmitted
+    // composite target, abandon the old extended confirmation and retain one
+    // complete latest-state patch for the next generation.
+    confirm_mask &= ~this->coalesce_extended_supersession_(in_flight_envelope_.intent, confirm_mask, command);
+
+    // For independent fields, a newer request for the same field supersedes
+    // semantic confirmation of the value that just completed transmission.
     MhiCommandConfirmation in_flight_confirmation{};
     in_flight_confirmation.stage(in_flight_envelope_.intent, confirm_mask, completion.completed_at_ms);
     confirm_mask &= ~in_flight_confirmation.supersede(command);
@@ -87,6 +100,7 @@ bool MhiCommandCoordinator::on_tx_completion(const MhiTxCompletion& completion, 
     }
   } else {
     restore_command_mask_(command, in_flight_command_before_build_, in_flight_envelope_.command_mask);
+    restore_intent_mask_(command, in_flight_envelope_.intent, in_flight_envelope_.command_mask);
   }
 
   command_in_flight_ = false;
@@ -115,7 +129,15 @@ uint32_t MhiCommandCoordinator::settle_pending_mask(uint32_t mask) {
 }
 
 uint32_t MhiCommandCoordinator::supersede_pending(const MhiCommandState& patch) {
-  const uint32_t superseded = confirmation_.supersede(patch);
+  uint32_t superseded = 0U;
+
+  if (confirmation_.has_pending()) {
+    const uint32_t obsolete_extended =
+        this->coalesce_extended_supersession_(confirmation_.pending_intent(), confirmation_.pending_mask(), patch);
+    superseded |= confirmation_.settle_pending_mask(obsolete_extended);
+  }
+
+  superseded |= confirmation_.supersede(patch);
   if (!confirmation_.has_pending()) {
     this->reset_attempts_();
   }
@@ -133,7 +155,6 @@ MhiCommandTimeoutResult MhiCommandCoordinator::expire(uint32_t now_ms, MhiComman
   result.attempt = confirmation_attempt_ == 0U ? 1U : confirmation_attempt_;
   const uint32_t already_queued = command.pending_command_mask() & expiration.mask;
   result.superseded_mask = already_queued;
-
   if (result.attempt < kMhiMaxCommandAttempts) {
     result.retry_mask = restore_intent_mask_(command, expiration.intent, expiration.mask & ~already_queued);
     result.superseded_mask |= expiration.mask & ~(result.retry_mask | result.superseded_mask);
@@ -146,7 +167,6 @@ MhiCommandTimeoutResult MhiCommandCoordinator::expire(uint32_t now_ms, MhiComman
     result.exhausted_mask = expiration.mask & ~already_queued;
     this->reset_attempts_();
   }
-
   return result;
 }
 
@@ -158,6 +178,69 @@ uint32_t MhiCommandCoordinator::staged_timeout_mask(uint32_t now_ms, uint32_t ti
 
   staged_timeout_reported_ = true;
   return in_flight_envelope_.command_mask;
+}
+
+uint32_t MhiCommandCoordinator::coalesce_extended_supersession_(const MhiCommandIntent& intent, uint32_t confirm_mask,
+                                                                const MhiCommandState& patch) {
+  const uint32_t extended_confirm_mask = confirm_mask & kMhiExtendedLouverCommandMask;
+  const bool crosses_shared_domain =
+      ((extended_confirm_mask & MHI_COMMAND_HORIZONTAL_VANE) != 0U && patch.three_d_auto_set) ||
+      ((extended_confirm_mask & MHI_COMMAND_THREE_D_AUTO) != 0U && patch.horizontal_vane_set);
+  if (extended_confirm_mask == 0U || !intent.has_extended_louver_context || !crosses_shared_domain) {
+    return 0U;
+  }
+
+  MhiCommandState desired{};
+  desired.horizontal_vane_set = true;
+  desired.horizontal_vane = intent.horizontal_vane;
+  desired.three_d_auto_set = true;
+  desired.three_d_auto = intent.three_d_auto;
+
+  if (coalesced_extended_patch_pending_) {
+    if (coalesced_extended_patch_.horizontal_vane_set) {
+      desired.horizontal_vane = coalesced_extended_patch_.horizontal_vane;
+    }
+    if (coalesced_extended_patch_.three_d_auto_set) {
+      desired.three_d_auto = coalesced_extended_patch_.three_d_auto;
+    }
+  }
+
+  if (patch.horizontal_vane_set) {
+    desired.horizontal_vane = patch.horizontal_vane;
+  }
+  if (patch.three_d_auto_set) {
+    desired.three_d_auto = patch.three_d_auto;
+  }
+
+  const bool composite_changed =
+      desired.horizontal_vane != intent.horizontal_vane || desired.three_d_auto != intent.three_d_auto;
+  if (!composite_changed) {
+    return 0U;
+  }
+
+  coalesced_extended_patch_ = desired;
+  coalesced_extended_patch_pending_ = true;
+  return extended_confirm_mask;
+}
+
+void MhiCommandCoordinator::apply_coalesced_extended_patch_(MhiCommandState& command) {
+  if (!coalesced_extended_patch_pending_) {
+    return;
+  }
+
+  // Explicitly queued values are newer than the cached companion context and
+  // therefore take precedence. Fill only the missing side of the composite.
+  if (!command.horizontal_vane_set && coalesced_extended_patch_.horizontal_vane_set) {
+    command.horizontal_vane_set = true;
+    command.horizontal_vane = coalesced_extended_patch_.horizontal_vane;
+  }
+  if (!command.three_d_auto_set && coalesced_extended_patch_.three_d_auto_set) {
+    command.three_d_auto_set = true;
+    command.three_d_auto = coalesced_extended_patch_.three_d_auto;
+  }
+
+  coalesced_extended_patch_ = {};
+  coalesced_extended_patch_pending_ = false;
 }
 
 void MhiCommandCoordinator::restore_command_mask_(MhiCommandState& destination, const MhiCommandState& source,
@@ -202,7 +285,6 @@ void MhiCommandCoordinator::restore_command_mask_(MhiCommandState& destination, 
 uint32_t MhiCommandCoordinator::restore_intent_mask_(MhiCommandState& destination, const MhiCommandIntent& intent,
                                                      uint32_t mask) {
   uint32_t restored = 0U;
-
   if ((mask & MHI_COMMAND_POWER) != 0U && !destination.power_set) {
     destination.power_set = true;
     destination.power = intent.power;
@@ -238,7 +320,6 @@ uint32_t MhiCommandCoordinator::restore_intent_mask_(MhiCommandState& destinatio
     destination.three_d_auto = intent.three_d_auto;
     restored |= MHI_COMMAND_THREE_D_AUTO;
   }
-
   return restored;
 }
 

--- a/components/MhiAcCtrl/mhi_command_coordinator.h
+++ b/components/MhiAcCtrl/mhi_command_coordinator.h
@@ -10,6 +10,7 @@ namespace esphome {
 namespace mhi_ac_ctrl {
 
 constexpr uint8_t kMhiMaxCommandAttempts = 3U;
+constexpr uint32_t kMhiExtendedLouverCommandMask = MHI_COMMAND_HORIZONTAL_VANE | MHI_COMMAND_THREE_D_AUTO;
 
 struct MhiCommandTimeoutResult {
   uint32_t timed_out_mask{0U};
@@ -31,7 +32,6 @@ class MhiCommandCoordinator {
 
   bool prepare_next(MhiCommandState& command, MhiTxRuntime& runtime, const MhiTxBuildConfig& config,
                     MhiFrameBuffer& frame, MhiTxBuildResult& result, MhiTxEnvelope& envelope);
-
   void on_stage_result(const MhiTxEnvelope& envelope, const MhiCommandState& command_before_build,
                        MhiCommandState& command, bool staged, uint32_t staged_at_ms = 0U);
 
@@ -40,7 +40,6 @@ class MhiCommandCoordinator {
   uint32_t observe_status(const MhiStatusState& status);
   uint32_t settle_pending_mask(uint32_t mask);
   uint32_t supersede_pending(const MhiCommandState& patch);
-
   MhiCommandTimeoutResult expire(uint32_t now_ms, MhiCommandState& command);
 
   uint32_t staged_timeout_mask(uint32_t now_ms, uint32_t timeout_ms);
@@ -80,6 +79,12 @@ class MhiCommandCoordinator {
  private:
   static void restore_command_mask_(MhiCommandState& destination, const MhiCommandState& source, uint32_t mask);
   static uint32_t restore_intent_mask_(MhiCommandState& destination, const MhiCommandIntent& intent, uint32_t mask);
+
+  // Returns the extended bits from confirm_mask that have become obsolete.
+  // The latest complete horizontal + 3D target is retained for the next build.
+  uint32_t coalesce_extended_supersession_(const MhiCommandIntent& intent, uint32_t confirm_mask,
+                                           const MhiCommandState& patch);
+  void apply_coalesced_extended_patch_(MhiCommandState& command);
   void reset_attempts_();
 
   MhiCommandConfirmation confirmation_{};
@@ -92,6 +97,9 @@ class MhiCommandCoordinator {
   uint8_t confirmation_attempt_{0U};
   uint32_t in_flight_staged_ms_{0U};
   bool staged_timeout_reported_{false};
+
+  MhiCommandState coalesced_extended_patch_{};
+  bool coalesced_extended_patch_pending_{false};
 };
 
 }  // namespace mhi_ac_ctrl

--- a/components/MhiAcCtrl/mhi_status_decoder.cpp
+++ b/components/MhiAcCtrl/mhi_status_decoder.cpp
@@ -99,10 +99,11 @@ bool MhiStatusDecoder::decode_mosi(const MhiFrameView& mosi, MhiDecodedStatus& o
       }
     }
 
-    if (decoded.has_horizontal_vane) {
-      decoded.has_3d_auto = true;
-      decoded.three_d_auto = (mosi[DB17] & 0x04U) != 0U;
-    }
+    // 3D Auto is DB17 bit 2 and is independent of DB16 horizontal
+    // position validity. Preserve it even when the retained horizontal
+    // position cannot be normalised to the public 1..7/swing model.
+    decoded.has_3d_auto = true;
+    decoded.three_d_auto = (mosi[DB17] & 0x04U) != 0U;
   }
 
   out = decoded;

--- a/components/MhiAcCtrl/mhi_tx_builder.cpp
+++ b/components/MhiAcCtrl/mhi_tx_builder.cpp
@@ -240,56 +240,71 @@ void MhiTxBuilder::apply_commands(MhiFrameBuffer& out, MhiCommandState& command,
   out.data[DB3] = runtime.room_temp_override_raw;
 
   if (out.len == kMhiFrame33Bytes) {
-    out.data[DB16] = 0x00U;
-    out.data[DB17] = 0x00U;
+    const bool horizontal_requested = command.horizontal_vane_set;
+    const bool three_d_requested = command.three_d_auto_set;
+    const bool has_extended_request = horizontal_requested || three_d_requested;
+    if (has_extended_request) {
+      // DB16/DB17 are one composite register domain. Start from the last
+      // confirmed state, overlay only the requested fields, then encode the
+      // complete command. This prevents horizontal writes from clearing 3D
+      // Auto and prevents 3D writes from changing the horizontal state.
+      const bool has_preserved_context = config.has_extended_louver_state;
+      bool desired_horizontal_swing = false;
+      uint8_t desired_horizontal_vane = 1U;
+      bool desired_three_d_auto = false;
+      uint8_t preserved_swing_db16 = 0U;
 
-    const bool use_preserved_louver =
-        command.three_d_auto_set && !command.horizontal_vane_set && config.has_extended_louver_state;
-
-    if (use_preserved_louver) {
-      out.data[DB16] = config.extended_louver_db16;
-      out.data[DB17] = config.extended_louver_db17;
-      result.intent.horizontal_vane =
-          config.extended_louver_horizontal_swing ? 8U : config.extended_louver_horizontal_vane;
-      result.intent.has_extended_louver_context = true;
-    }
-
-    if (command.horizontal_vane_set) {
-      result.intent.horizontal_vane = command.horizontal_vane;
-      result.intent.has_extended_louver_context = true;
-
-      if (command.horizontal_vane == 8U) {
-        // Horizontal swing is a composite extended-louver state. DB16 may be
-        // returned by the AC with the previous/live position, so DB17 carries
-        // the authoritative swing flag while DB16 is left neutral in TX.
-        out.data[DB17] = 0x0BU;
-      } else if (command.horizontal_vane >= 1U && command.horizontal_vane <= 7U) {
-        out.data[DB16] = static_cast<uint8_t>(0x10U | (command.horizontal_vane - 1U));
-        out.data[DB17] = 0x0AU;
+      if (has_preserved_context) {
+        desired_horizontal_swing = config.extended_louver_horizontal_swing;
+        if (config.extended_louver_horizontal_vane >= 1U && config.extended_louver_horizontal_vane <= 7U) {
+          desired_horizontal_vane = config.extended_louver_horizontal_vane;
+        } else {
+          const uint8_t raw_position = static_cast<uint8_t>(config.extended_louver_db16 & 0x07U);
+          if (raw_position <= 6U) {
+            desired_horizontal_vane = static_cast<uint8_t>(raw_position + 1U);
+          }
+        }
+        desired_three_d_auto = config.extended_louver_three_d_auto;
+        preserved_swing_db16 = config.extended_louver_db16;
       }
 
-      command.horizontal_vane_set = false;
-      result.encoded_command_mask |= MHI_COMMAND_HORIZONTAL_VANE;
-      result.intent.mask |= MHI_COMMAND_HORIZONTAL_VANE;
-    }
-
-    if (command.three_d_auto_set) {
-      if (!use_preserved_louver && !result.intent.has_extended_louver_context) {
-        result.intent.horizontal_vane = 1U;
+      if (horizontal_requested) {
+        desired_horizontal_swing = command.horizontal_vane == 8U;
+        if (!desired_horizontal_swing && command.horizontal_vane >= 1U && command.horizontal_vane <= 7U) {
+          desired_horizontal_vane = command.horizontal_vane;
+        }
+        result.encoded_command_mask |= MHI_COMMAND_HORIZONTAL_VANE;
+        result.intent.mask |= MHI_COMMAND_HORIZONTAL_VANE;
+        command.horizontal_vane_set = false;
       }
 
-      out.data[DB17] = static_cast<uint8_t>((out.data[DB17] & ~0x04U) | (command.three_d_auto ? 0x04U : 0x00U));
+      if (three_d_requested) {
+        desired_three_d_auto = command.three_d_auto;
+        result.encoded_command_mask |= MHI_COMMAND_THREE_D_AUTO;
+        result.intent.mask |= MHI_COMMAND_THREE_D_AUTO;
+        command.three_d_auto_set = false;
+      }
 
-      // Louver command-indicator bits (0x08 | 0x02) must be asserted for the
-      // AC to accept the write. The previous conditional skipped this when
-      // bit 0x01 was carried over from the preserved louver state, leaving
-      // DB17 as 0x05 which the AC treats as a status echo, not a command.
-      out.data[DB17] |= 0x0AU;
+      if (desired_horizontal_swing) {
+        // MOSI feedback retains the previous fixed DB16 position while swing
+        // is active. Preserve it when known and use DB17 bit 0 as the
+        // authoritative swing state.
+        out.data[DB16] = preserved_swing_db16;
+      } else if (horizontal_requested || has_preserved_context) {
+        out.data[DB16] = static_cast<uint8_t>(0x10U | (desired_horizontal_vane - 1U));
+      } else {
+        // Preserve the pre-spike fallback for a 3D-only request received
+        // before the first extended-louver status has been learned.
+        out.data[DB16] = 0x00U;
+      }
+      out.data[DB17] = static_cast<uint8_t>(0x0AU | (desired_horizontal_swing ? 0x01U : 0x00U) |
+                                            (desired_three_d_auto ? 0x04U : 0x00U));
 
-      result.intent.three_d_auto = command.three_d_auto;
-      command.three_d_auto_set = false;
-      result.encoded_command_mask |= MHI_COMMAND_THREE_D_AUTO;
-      result.intent.mask |= MHI_COMMAND_THREE_D_AUTO;
+      result.intent.horizontal_vane = desired_horizontal_swing ? 8U : desired_horizontal_vane;
+      result.intent.three_d_auto = desired_three_d_auto;
+      // Companion-state confirmation is safe only when the preserved state is
+      // known, or when both halves were explicitly supplied in this command.
+      result.intent.has_extended_louver_context = horizontal_requested || has_preserved_context;
     }
   } else {
     if (command.horizontal_vane_set) {

--- a/components/MhiAcCtrl/select/mhi_vertical_vanes_select.cpp
+++ b/components/MhiAcCtrl/select/mhi_vertical_vanes_select.cpp
@@ -31,6 +31,15 @@ void MhiVerticalVanesSelect::control(const std::string& value) {
     return;
   }
 
+  // Home Assistant can call select_option with the value that is already
+  // published. Do not create a new confirmation generation for a no-op. The
+  // command coordinator still suppresses a duplicate while the same command
+  // is pending; this covers the already-confirmed case seen in the matrix.
+  if (this->current_option() == value) {
+    ESP_LOGD(TAG, "Duplicate or already-confirmed vertical vanes request ignored: %s", value.c_str());
+    return;
+  }
+
   this->parent_->request_vertical_vane_command(static_cast<uint8_t>(index.value() + 1U));
 
   ESP_LOGD(TAG, "Vertical vanes command staged: %s; waiting for confirmed MOSI state", value.c_str());

--- a/notes/FINDINGS_LOUVERS_3D_AUTO.md
+++ b/notes/FINDINGS_LOUVERS_3D_AUTO.md
@@ -1,0 +1,295 @@
+# Vertical Vane, Horizontal Vane, and 3D Auto Findings
+
+## Summary
+
+Hardware testing confirmed that vertical vane state, horizontal vane state, and 3D Auto are represented across two protocol areas:
+
+- vertical vane uses `DB0` and `DB1` in the base frame area;
+- horizontal vane and 3D Auto use `DB16` and `DB17` in the 33-byte extended frame area;
+- horizontal vane and 3D Auto form one composite `DB16`/`DB17` register domain;
+- 3D Auto itself remains an independent semantic bit: `DB17[2]`, mask `0x04`.
+
+The production implementation must therefore preserve the complete horizontal/3D state whenever either field changes. A horizontal-only command must not clear 3D Auto, and a 3D-only command must not alter horizontal position or swing.
+
+The final hardware matrix completed all 80 combinations successfully:
+
+```text
+Vertical vane matches:              80/80
+Horizontal vane matches:            80/80
+3D Auto matches:                    80/80
+Complete requested-state matches:   80/80
+Retry exhaustions:                   0
+Pending confirmation mask at end:   0x00000000
+```
+
+## Bus direction and frame terminology
+
+The air conditioner is the SPI-like bus master:
+
+- `MOSI` is sent by the air conditioner and is used as authoritative returned status/confirmation;
+- `MISO` is sent by the controller and carries requested commands;
+- the bus has no conventional chip-select signal, so frame boundaries are inferred by the transport.
+
+The byte names are used consistently in both directions. For example, a horizontal command is encoded in MISO `DB16`/`DB17`, and its result is confirmed from MOSI `DB16`/`DB17`.
+
+## 33-byte frame positions
+
+The extended louver fields are not inside the original 20-byte data area. They appear after the original checksum in the 33-byte frame.
+
+| Logical field | Raw byte index | Frame area | Louver meaning |
+|---|---:|---|---|
+| `SB0`–`SB2` | 0–2 | Signature | Frame signature |
+| `DB0` | 3 | Base data | Vertical command/set and vertical swing |
+| `DB1` | 4 | Base data | Vertical fixed position |
+| `DB2`–`DB14` | 5–17 | Base data | Other status/command fields |
+| `CBH` / `CBL` | 18–19 | Base checksum | Checksum for the original frame area |
+| `DB15` | 20 | Extended data | Extended field |
+| `DB16` | 21 | Extended data | Horizontal fixed position or retained position during swing |
+| `DB17` | 22 | Extended data | Horizontal swing and 3D Auto state |
+| `DB18`–`DB26` | 23–31 | Extended data | Other extended fields |
+| `CBL2` | 32 | Extended checksum | Final checksum byte for the 33-byte frame |
+
+This positioning matters because 20-byte units do not expose `DB16`/`DB17`. Horizontal vane and 3D Auto commands are therefore supported only on the extended 33-byte path.
+
+## Confirmed vertical-vane mapping
+
+| Vertical state | `DB0` | `DB1` | Semantic confirmation |
+|---|---:|---:|---|
+| Up | `0x80` | `0x80` | Swing off and position 1 |
+| Up/Center | `0x80` | `0x90` | Swing off and position 2 |
+| Center/Down | `0x80` | `0xA0` | Swing off and position 3 |
+| Down | `0x80` | `0xB0` | Swing off and position 4 |
+| Swing | `0xC0` | Previous fixed position retained in feedback | `DB0[6]` set; ignore retained `DB1` position bits |
+
+Relevant bits:
+
+- `DB0[7]` participates in the vertical command/set form;
+- `DB0[6]` is vertical swing;
+- `DB1[5:4]` contains fixed vertical position;
+- `DB1[7]` participates in the fixed-position command/set form.
+
+When vertical swing is active, the returned `DB1` position bits retain the previous fixed position. They do not describe the current vane mode and must not be compared during swing confirmation.
+
+## Confirmed horizontal-vane and 3D Auto mapping
+
+| Horizontal state | `DB16` | `DB17`, 3D OFF | `DB17`, 3D ON |
+|---|---:|---:|---:|
+| Left | `0x10` | `0x0A` | `0x0E` |
+| Left/Center | `0x11` | `0x0A` | `0x0E` |
+| Center | `0x12` | `0x0A` | `0x0E` |
+| Center/Right | `0x13` | `0x0A` | `0x0E` |
+| Right | `0x14` | `0x0A` | `0x0E` |
+| Wide | `0x15` | `0x0A` | `0x0E` |
+| Spot | `0x16` | `0x0A` | `0x0E` |
+| Swing | `retained†` | `0x0B` | `0x0F` |
+
+Relevant `DB17` bits:
+
+- `DB17[0]`, mask `0x01`: horizontal swing;
+- `DB17[2]`, mask `0x04`: 3D Auto;
+- the observed fixed-position base value is `0x0A`;
+- the observed swing base value is `0x0B`.
+
+The semantics of every set bit in the invariant `0x0A` base have not been independently identified. The tested implementation preserves the complete observed command shape instead of assigning unsupported meanings to those bits.
+
+When horizontal swing is active, MOSI feedback retains the previous fixed position in `DB16`. `DB17[0]` is the authoritative swing indicator. The builder preserves the known raw `DB16` value when transmitting swing, and confirmation deliberately ignores `DB16` while swing is requested.
+
+## Complete 80-combination feedback matrix
+
+The matrix below documents the expected MOSI feedback state after each requested combination has settled. It does not imply that all four bytes are written in one MISO command frame: vertical, horizontal, and 3D commands may be staged separately, while MOSI feedback reports the resulting persistent state.
+
+Each row represents one vertical/horizontal pair and contains both 3D states. Forty vane pairs multiplied by two 3D states gives the complete 80-case matrix.
+
+| Matrix cases OFF / ON | Vertical | `DB0` | `DB1` | Horizontal | `DB16` | `DB17` OFF | `DB17` ON |
+|---:|---|---:|---:|---|---:|---:|---:|
+| 1 / 2 | Up | `0x80` | `0x80` | Left | `0x10` | `0x0A` | `0x0E` |
+| 3 / 4 | Up | `0x80` | `0x80` | Left/Center | `0x11` | `0x0A` | `0x0E` |
+| 5 / 6 | Up | `0x80` | `0x80` | Center | `0x12` | `0x0A` | `0x0E` |
+| 7 / 8 | Up | `0x80` | `0x80` | Center/Right | `0x13` | `0x0A` | `0x0E` |
+| 9 / 10 | Up | `0x80` | `0x80` | Right | `0x14` | `0x0A` | `0x0E` |
+| 11 / 12 | Up | `0x80` | `0x80` | Wide | `0x15` | `0x0A` | `0x0E` |
+| 13 / 14 | Up | `0x80` | `0x80` | Spot | `0x16` | `0x0A` | `0x0E` |
+| 15 / 16 | Up | `0x80` | `0x80` | Swing | `retained†` | `0x0B` | `0x0F` |
+| 17 / 18 | Up/Center | `0x80` | `0x90` | Left | `0x10` | `0x0A` | `0x0E` |
+| 19 / 20 | Up/Center | `0x80` | `0x90` | Left/Center | `0x11` | `0x0A` | `0x0E` |
+| 21 / 22 | Up/Center | `0x80` | `0x90` | Center | `0x12` | `0x0A` | `0x0E` |
+| 23 / 24 | Up/Center | `0x80` | `0x90` | Center/Right | `0x13` | `0x0A` | `0x0E` |
+| 25 / 26 | Up/Center | `0x80` | `0x90` | Right | `0x14` | `0x0A` | `0x0E` |
+| 27 / 28 | Up/Center | `0x80` | `0x90` | Wide | `0x15` | `0x0A` | `0x0E` |
+| 29 / 30 | Up/Center | `0x80` | `0x90` | Spot | `0x16` | `0x0A` | `0x0E` |
+| 31 / 32 | Up/Center | `0x80` | `0x90` | Swing | `retained†` | `0x0B` | `0x0F` |
+| 33 / 34 | Center/Down | `0x80` | `0xA0` | Left | `0x10` | `0x0A` | `0x0E` |
+| 35 / 36 | Center/Down | `0x80` | `0xA0` | Left/Center | `0x11` | `0x0A` | `0x0E` |
+| 37 / 38 | Center/Down | `0x80` | `0xA0` | Center | `0x12` | `0x0A` | `0x0E` |
+| 39 / 40 | Center/Down | `0x80` | `0xA0` | Center/Right | `0x13` | `0x0A` | `0x0E` |
+| 41 / 42 | Center/Down | `0x80` | `0xA0` | Right | `0x14` | `0x0A` | `0x0E` |
+| 43 / 44 | Center/Down | `0x80` | `0xA0` | Wide | `0x15` | `0x0A` | `0x0E` |
+| 45 / 46 | Center/Down | `0x80` | `0xA0` | Spot | `0x16` | `0x0A` | `0x0E` |
+| 47 / 48 | Center/Down | `0x80` | `0xA0` | Swing | `retained†` | `0x0B` | `0x0F` |
+| 49 / 50 | Down | `0x80` | `0xB0` | Left | `0x10` | `0x0A` | `0x0E` |
+| 51 / 52 | Down | `0x80` | `0xB0` | Left/Center | `0x11` | `0x0A` | `0x0E` |
+| 53 / 54 | Down | `0x80` | `0xB0` | Center | `0x12` | `0x0A` | `0x0E` |
+| 55 / 56 | Down | `0x80` | `0xB0` | Center/Right | `0x13` | `0x0A` | `0x0E` |
+| 57 / 58 | Down | `0x80` | `0xB0` | Right | `0x14` | `0x0A` | `0x0E` |
+| 59 / 60 | Down | `0x80` | `0xB0` | Wide | `0x15` | `0x0A` | `0x0E` |
+| 61 / 62 | Down | `0x80` | `0xB0` | Spot | `0x16` | `0x0A` | `0x0E` |
+| 63 / 64 | Down | `0x80` | `0xB0` | Swing | `retained†` | `0x0B` | `0x0F` |
+| 65 / 66 | Swing | `0xC0` | `retained*` | Left | `0x10` | `0x0A` | `0x0E` |
+| 67 / 68 | Swing | `0xC0` | `retained*` | Left/Center | `0x11` | `0x0A` | `0x0E` |
+| 69 / 70 | Swing | `0xC0` | `retained*` | Center | `0x12` | `0x0A` | `0x0E` |
+| 71 / 72 | Swing | `0xC0` | `retained*` | Center/Right | `0x13` | `0x0A` | `0x0E` |
+| 73 / 74 | Swing | `0xC0` | `retained*` | Right | `0x14` | `0x0A` | `0x0E` |
+| 75 / 76 | Swing | `0xC0` | `retained*` | Wide | `0x15` | `0x0A` | `0x0E` |
+| 77 / 78 | Swing | `0xC0` | `retained*` | Spot | `0x16` | `0x0A` | `0x0E` |
+| 79 / 80 | Swing | `0xC0` | `retained*` | Swing | `retained†` | `0x0B` | `0x0F` |
+
+\* **Vertical swing:** returned `DB1` retains the previous fixed position. Confirmation checks `DB0[6]` and ignores the retained position.
+
+† **Horizontal swing:** returned `DB16` retains the previous fixed position. The builder preserves the known value; before extended-louver context has been learned, the fallback command value may be `0x00`. Confirmation checks `DB17[0]` and ignores retained `DB16` position bits.
+
+## Composite horizontal/3D finding
+
+The original failure came from treating horizontal vane and 3D Auto as unrelated commands even though both are encoded through `DB16`/`DB17`.
+
+A horizontal-only command previously generated `DB17=0x0A` or `0x0B` without preserving bit `0x04`. If 3D Auto was already enabled, the horizontal command therefore cleared it before the explicit 3D request was processed.
+
+The correct command-building model is:
+
+```text
+desired horizontal state = last confirmed horizontal state
+desired 3D state         = last confirmed 3D state
+
+overlay newly requested horizontal state, when present
+overlay newly requested 3D state, when present
+
+encode the complete DB16/DB17 pair
+```
+
+This produces the required preservation behaviour:
+
+- horizontal-only commands preserve 3D Auto;
+- 3D-only commands preserve horizontal position or swing;
+- a combined horizontal + 3D command encodes both latest values together.
+
+## Asymmetric confirmation semantics
+
+Horizontal and 3D share an encoded register domain, but they do not use identical semantic confirmation rules.
+
+| Pending command | Confirmation rule |
+|---|---|
+| Vertical fixed position | Vertical swing is off and returned position matches |
+| Vertical swing | `DB0[6]` is set; ignore retained `DB1` position |
+| Horizontal fixed position | Horizontal swing is off, returned position matches, and the preserved 3D companion state still matches |
+| Horizontal swing | `DB17[0]` is set, ignore retained `DB16`, and the preserved 3D companion state still matches |
+| 3D Auto only | Returned `DB17[2]` matches; horizontal position is preserved context and does not block confirmation |
+
+This asymmetry is intentional:
+
+- a horizontal command encodes the full composite pair and must prove that it did not unintentionally change 3D Auto;
+- a 3D-only request changes one independent bit and should confirm from that bit alone.
+
+3D state must also remain decodable when `DB16` contains an unknown fixed-position value. Invalid or unrecognised horizontal position feedback must not suppress valid `DB17[2]` state.
+
+## Pending-command supersession
+
+A second failure mode occurred when a horizontal command was transmitted but had not yet confirmed before a newer 3D request arrived. Waiting for the old timeout allowed obsolete intent to cross the diagnostic matrix case boundary.
+
+The coordinator now resolves the extended-louver domain using the latest desired state:
+
+```text
+confirmed state
++ pending intent
++ newly staged intent
+= latest desired composite state
+```
+
+When the latest desired state differs from the currently pending expected state:
+
+1. settle the obsolete confirmation generation;
+2. merge the latest horizontal and 3D intent;
+3. transmit a combined command using mask `0x60`;
+4. start a new confirmation generation for the combined state.
+
+The final matrix exercised this path three times:
+
+| Case | Requested state | Superseded | Replacement | Result |
+|---:|---|---:|---:|---|
+| 23 | Up/Center + Center/Right + 3D OFF | `0x20` | `0x60` | Confirmed |
+| 27 | Up/Center + Wide + 3D OFF | `0x20` | `0x60` | Confirmed |
+| 61 | Down + Spot + 3D OFF | `0x20` | `0x60` | Confirmed |
+
+All three combined replacements confirmed in approximately 140–154 ms and did not leak stale state into the next case.
+
+## Duplicate suppression and retry policy
+
+The matrix reuses the same vertical value across each group of horizontal/3D combinations. Reissuing those already-confirmed vertical values previously created unnecessary command traffic and confirmation timeouts.
+
+Vertical requests now use the same duplicate guard as horizontal and 3D requests. An already-confirmed value is ignored when there is no conflicting pending vertical generation.
+
+Successful hardware confirmations were normally reported within a few hundred milliseconds. An unmatched extended-louver command after several seconds behaved as an ignored command rather than a slowly settling mechanical state.
+
+The resulting retry policy is:
+
+- horizontal confirmation window: 3 seconds;
+- 3D Auto confirmation window: 3 seconds;
+- retry once using the latest coalesced intent;
+- report retry exhaustion if the replacement also remains unconfirmed.
+
+The complete matrix had three transient 3D timeouts. All three confirmed after one retry. There were no retry exhaustions.
+
+## Hardware validation
+
+The final 80-case run verified:
+
+- all five vertical states;
+- all eight horizontal states;
+- both 3D Auto states for every vertical/horizontal pair;
+- composite preservation for fixed horizontal positions and horizontal swing;
+- semantic swing confirmation with retained position fields;
+- duplicate vertical suppression;
+- early 3D retry;
+- immediate horizontal/3D supersession and `0x60` coalescing.
+
+The transport remained clean during the matrix and subsequent soak:
+
+```text
+Invalid frames:       0
+Checksum failures:    0
+Signature misses:     0
+Sync losses:          0
+Dropped bytes:        0
+TX failures:          0
+Queue errors:         0
+RMT re-arm errors:    0
+RX overwrites:        0
+Completion drops:     0
+```
+
+The single `invalid_len=1` counter was present from startup and did not increase. `tx_overwritten` increased under the deliberately aggressive test matrix without producing command failures or RX corruption.
+
+## Implementation outcome
+
+The production implementation now follows these rules:
+
+1. Treat `DB16`/`DB17` as one composite horizontal/3D encoding domain.
+2. Preserve confirmed companion state when only one field changes.
+3. Confirm 3D Auto independently from `DB17[2]`.
+4. Confirm horizontal commands against both requested horizontal state and preserved 3D context.
+5. Confirm swing semantically and ignore retained fixed-position fields.
+6. Supersede obsolete pending extended-louver generations immediately.
+7. Coalesce latest horizontal and 3D intent into mask `0x60` when required.
+8. Suppress already-confirmed duplicate vertical requests.
+9. Retry unconfirmed horizontal/3D commands after three seconds rather than allowing stale intent to remain pending.
+
+## Scope and limitations
+
+These findings were validated on the tested Mitsubishi Heavy Industries unit using 33-byte extended status frames. Other indoor-unit models may expose different extended fields or timing behaviour.
+
+The confirmed claims in this document are limited to:
+
+- the observed vertical, horizontal, and 3D mappings;
+- the returned status behaviour during fixed and swing modes;
+- the tested command-confirmation and retry behaviour;
+- the successful 80-case matrix and associated transport diagnostics.
+
+The exact purpose of every invariant bit in the extended command bytes remains undocumented and should not be inferred beyond the observed mappings above.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -37,6 +37,7 @@ fi
   tests/unit/test_frame_queue.cpp \
   tests/unit/test_duplex_tx_mailbox.cpp \
   tests/unit/test_command_coordinator.cpp \
+  tests/unit/test_command_coordinator_extended_supersession.cpp \
   tests/unit/test_worker_policy.cpp \
   tests/unit/test_worker_decoded_store.cpp \
   tests/unit/test_frame_catalog.cpp \

--- a/tests/unit/mhi_test_common.h
+++ b/tests/unit/mhi_test_common.h
@@ -227,6 +227,7 @@ void command_coordinator_supersedes_pending_confirmation_with_newer_value();
 void command_coordinator_does_not_confirm_old_value_when_newer_request_is_queued();
 void command_coordinator_retries_only_remaining_fields_and_caps_attempts();
 void command_coordinator_reports_staged_timeout_once();
+void command_coordinator_extended_louver_supersession_suite();
 void tx_completion_queue_preserves_order_and_rejects_overflow();
 
 
@@ -294,10 +295,11 @@ void command_confirmation_times_out_unconfirmed_commands();
 void command_confirmation_detects_duplicate_pending_commands();
 void command_confirmation_confirms_horizontal_vane_feedback();
 void command_confirmation_confirms_horizontal_swing_feedback();
+void command_confirmation_vertical_swing_ignores_retained_position();
 void command_confirmation_confirms_3d_auto_feedback();
 void command_confirmation_accepts_3d_auto_when_louver_context_changes();
 void command_confirmation_supersedes_older_pending_value();
-void command_confirmation_uses_longer_timeout_for_extended_louver_commands();
+void command_confirmation_uses_short_timeout_for_extended_louver_commands();
 void command_confirmation_reports_pending_age_for_settle_window();
 void command_confirmation_can_settle_extended_louver_pending_mask();
 void command_state_clears_pending_mask();

--- a/tests/unit/mhi_unit_test_main.cpp
+++ b/tests/unit/mhi_unit_test_main.cpp
@@ -44,6 +44,7 @@ int main() {
   command_coordinator_does_not_confirm_old_value_when_newer_request_is_queued();
   command_coordinator_retries_only_remaining_fields_and_caps_attempts();
   command_coordinator_reports_staged_timeout_once();
+  command_coordinator_extended_louver_supersession_suite();
   tx_completion_queue_preserves_order_and_rejects_overflow();
 
   worker_decoded_store_latest_status_overwrites_stale_status();
@@ -120,10 +121,11 @@ int main() {
   command_confirmation_detects_duplicate_pending_commands();
   command_confirmation_confirms_horizontal_vane_feedback();
   command_confirmation_confirms_horizontal_swing_feedback();
+  command_confirmation_vertical_swing_ignores_retained_position();
   command_confirmation_confirms_3d_auto_feedback();
   command_confirmation_accepts_3d_auto_when_louver_context_changes();
   command_confirmation_supersedes_older_pending_value();
-  command_confirmation_uses_longer_timeout_for_extended_louver_commands();
+  command_confirmation_uses_short_timeout_for_extended_louver_commands();
   command_confirmation_reports_pending_age_for_settle_window();
   command_confirmation_can_settle_extended_louver_pending_mask();
   command_state_clears_pending_mask();

--- a/tests/unit/test_command_confirmation.cpp
+++ b/tests/unit/test_command_confirmation.cpp
@@ -246,6 +246,23 @@ void command_confirmation_confirms_horizontal_swing_feedback() {
   EXPECT_FALSE(confirmation.has_pending());
 }
 
+void command_confirmation_vertical_swing_ignores_retained_position() {
+  MhiCommandConfirmation confirmation{};
+
+  MhiCommandIntent intent{};
+  intent.mask = MHI_COMMAND_VERTICAL_VANE;
+  intent.vertical_vane = 5U;
+  confirmation.stage(intent, intent.mask, 1000U);
+
+  MhiStatusState status{};
+  status.valid = true;
+  status.vanes_swing = true;
+  status.vertical_vane = 3U;
+
+  EXPECT_EQ(confirmation.observe_status(status), static_cast<uint32_t>(MHI_COMMAND_VERTICAL_VANE));
+  EXPECT_FALSE(confirmation.has_pending());
+}
+
 void command_confirmation_confirms_3d_auto_feedback() {
   MhiCommandConfirmation confirmation{};
 
@@ -311,7 +328,7 @@ void command_confirmation_supersedes_older_pending_value() {
   EXPECT_FALSE(confirmation.has_pending());
 }
 
-void command_confirmation_uses_longer_timeout_for_extended_louver_commands() {
+void command_confirmation_uses_short_timeout_for_extended_louver_commands() {
   MhiCommandConfirmation confirmation{};
 
   MhiCommandIntent intent{};
@@ -320,11 +337,21 @@ void command_confirmation_uses_longer_timeout_for_extended_louver_commands() {
 
   confirmation.stage(intent, intent.mask, 1000U);
 
-  EXPECT_EQ(confirmation.expire(10999U).mask, 0U);
+  EXPECT_EQ(confirmation.expire(1000U + kMhiThreeDAutoConfirmationTimeoutMs - 1U).mask, 0U);
   EXPECT_TRUE(confirmation.has_pending());
-  EXPECT_EQ(confirmation.expire(20999U).mask, 0U);
+  EXPECT_EQ(confirmation.expire(1000U + kMhiThreeDAutoConfirmationTimeoutMs).mask,
+            static_cast<uint32_t>(MHI_COMMAND_THREE_D_AUTO));
+  EXPECT_FALSE(confirmation.has_pending());
+
+  intent = {};
+  intent.mask = MHI_COMMAND_HORIZONTAL_VANE;
+  intent.horizontal_vane = 4U;
+  confirmation.stage(intent, intent.mask, 5000U);
+
+  EXPECT_EQ(confirmation.expire(5000U + kMhiExtendedLouverConfirmationTimeoutMs - 1U).mask, 0U);
   EXPECT_TRUE(confirmation.has_pending());
-  EXPECT_EQ(confirmation.expire(21000U).mask, static_cast<uint32_t>(MHI_COMMAND_THREE_D_AUTO));
+  EXPECT_EQ(confirmation.expire(5000U + kMhiExtendedLouverConfirmationTimeoutMs).mask,
+            static_cast<uint32_t>(MHI_COMMAND_HORIZONTAL_VANE));
   EXPECT_FALSE(confirmation.has_pending());
 }
 

--- a/tests/unit/test_command_coordinator_extended_supersession.cpp
+++ b/tests/unit/test_command_coordinator_extended_supersession.cpp
@@ -1,0 +1,283 @@
+#include "mhi_test_common.h"
+
+namespace mhi_unit_tests {
+namespace {
+
+struct PreparedCommand {
+  MhiCommandState before{};
+  MhiFrameBuffer frame{};
+  MhiTxBuildResult result{};
+  MhiTxEnvelope envelope{};
+};
+
+MhiTxBuildConfig make_extended_config(uint8_t horizontal_vane, bool horizontal_swing, bool three_d_auto) {
+  MhiTxBuildConfig config{};
+  config.frame_size = kMhiFrame33Bytes;
+  config.has_extended_louver_state = true;
+  config.extended_louver_horizontal_vane = horizontal_vane;
+  config.extended_louver_horizontal_swing = horizontal_swing;
+  config.extended_louver_three_d_auto = three_d_auto;
+  config.extended_louver_db16 = horizontal_vane >= 1U && horizontal_vane <= 7U
+                                      ? static_cast<uint8_t>(0x0FU + horizontal_vane)
+                                      : 0x16U;
+  config.extended_louver_db17 = static_cast<uint8_t>(0x0AU | (horizontal_swing ? 0x01U : 0U) |
+                                                      (three_d_auto ? 0x04U : 0U));
+  return config;
+}
+
+PreparedCommand prepare_command(MhiCommandCoordinator& coordinator, MhiCommandState& command, MhiTxRuntime& runtime,
+                                const MhiTxBuildConfig& config) {
+  PreparedCommand prepared{};
+  prepared.before = command;
+  const bool built = coordinator.prepare_next(command, runtime, config, prepared.frame, prepared.result,
+                                               prepared.envelope);
+  EXPECT_TRUE(built);
+  EXPECT_TRUE(prepared.envelope.valid());
+  return prepared;
+}
+
+void stage_command(MhiCommandCoordinator& coordinator, const PreparedCommand& prepared, MhiCommandState& command,
+                   uint32_t staged_at_ms) {
+  coordinator.on_stage_result(prepared.envelope, prepared.before, command, true, staged_at_ms);
+  EXPECT_TRUE(coordinator.has_command_in_flight());
+}
+
+void complete_command(MhiCommandCoordinator& coordinator, const PreparedCommand& prepared, MhiCommandState& command,
+                      uint32_t completed_at_ms) {
+  MhiTxCompletion completion{};
+  completion.kind = MhiTxKind::COMMAND;
+  completion.generation = prepared.envelope.generation;
+  completion.command_mask = prepared.envelope.command_mask;
+  completion.success = true;
+  completion.completed_at_ms = completed_at_ms;
+  const bool handled = coordinator.on_tx_completion(completion, command);
+  EXPECT_TRUE(handled);
+  EXPECT_TRUE(!coordinator.has_command_in_flight());
+}
+
+void pending_horizontal_swing_plus_3d_off_coalesces_immediately() {
+  MhiCommandCoordinator coordinator{};
+  MhiCommandState command{};
+  MhiTxRuntime runtime{};
+  const auto config = make_extended_config(7U, false, true);
+
+  command.horizontal_vane_set = true;
+  command.horizontal_vane = 8U;
+  const auto first = prepare_command(coordinator, command, runtime, config);
+  EXPECT_TRUE(first.result.encoded_command_mask == MHI_COMMAND_HORIZONTAL_VANE);
+  EXPECT_TRUE(first.frame.data[DB16] == 0x16U);
+  EXPECT_TRUE(first.frame.data[DB17] == 0x0FU);
+  stage_command(coordinator, first, command, 100U);
+  complete_command(coordinator, first, command, 150U);
+  EXPECT_TRUE(coordinator.pending_mask() == MHI_COMMAND_HORIZONTAL_VANE);
+
+  MhiCommandState patch{};
+  patch.three_d_auto_set = true;
+  patch.three_d_auto = false;
+  const uint32_t superseded = coordinator.supersede_pending(patch);
+  EXPECT_TRUE(superseded == MHI_COMMAND_HORIZONTAL_VANE);
+  EXPECT_TRUE(!coordinator.has_pending_confirmation());
+
+  command.three_d_auto_set = true;
+  command.three_d_auto = false;
+  const auto combined = prepare_command(coordinator, command, runtime, config);
+  EXPECT_TRUE(combined.result.encoded_command_mask == kMhiExtendedLouverCommandMask);
+  EXPECT_TRUE(combined.frame.data[DB16] == 0x16U);
+  EXPECT_TRUE(combined.frame.data[DB17] == 0x0BU);
+}
+
+void pending_fixed_horizontal_plus_3d_off_coalesces_immediately() {
+  MhiCommandCoordinator coordinator{};
+  MhiCommandState command{};
+  MhiTxRuntime runtime{};
+  const auto config = make_extended_config(4U, false, true);
+
+  command.horizontal_vane_set = true;
+  command.horizontal_vane = 5U;
+  const auto first = prepare_command(coordinator, command, runtime, config);
+  EXPECT_TRUE(first.frame.data[DB16] == 0x14U);
+  EXPECT_TRUE(first.frame.data[DB17] == 0x0EU);
+  stage_command(coordinator, first, command, 100U);
+  complete_command(coordinator, first, command, 150U);
+
+  MhiCommandState patch{};
+  patch.three_d_auto_set = true;
+  patch.three_d_auto = false;
+  EXPECT_TRUE(coordinator.supersede_pending(patch) == MHI_COMMAND_HORIZONTAL_VANE);
+  command.three_d_auto_set = true;
+  command.three_d_auto = false;
+
+  const auto combined = prepare_command(coordinator, command, runtime, config);
+  EXPECT_TRUE(combined.result.encoded_command_mask == kMhiExtendedLouverCommandMask);
+  EXPECT_TRUE(combined.frame.data[DB16] == 0x14U);
+  EXPECT_TRUE(combined.frame.data[DB17] == 0x0AU);
+}
+
+void pending_3d_plus_new_horizontal_preserves_3d_target() {
+  MhiCommandCoordinator coordinator{};
+  MhiCommandState command{};
+  MhiTxRuntime runtime{};
+  const auto config = make_extended_config(3U, false, false);
+
+  command.three_d_auto_set = true;
+  command.three_d_auto = true;
+  const auto first = prepare_command(coordinator, command, runtime, config);
+  EXPECT_TRUE(first.result.encoded_command_mask == MHI_COMMAND_THREE_D_AUTO);
+  EXPECT_TRUE(first.frame.data[DB16] == 0x12U);
+  EXPECT_TRUE(first.frame.data[DB17] == 0x0EU);
+  stage_command(coordinator, first, command, 100U);
+  complete_command(coordinator, first, command, 150U);
+  EXPECT_TRUE(coordinator.pending_mask() == MHI_COMMAND_THREE_D_AUTO);
+
+  MhiCommandState patch{};
+  patch.horizontal_vane_set = true;
+  patch.horizontal_vane = 5U;
+  EXPECT_TRUE(coordinator.supersede_pending(patch) == MHI_COMMAND_THREE_D_AUTO);
+  command.horizontal_vane_set = true;
+  command.horizontal_vane = 5U;
+
+  const auto combined = prepare_command(coordinator, command, runtime, config);
+  EXPECT_TRUE(combined.result.encoded_command_mask == kMhiExtendedLouverCommandMask);
+  EXPECT_TRUE(combined.frame.data[DB16] == 0x14U);
+  EXPECT_TRUE(combined.frame.data[DB17] == 0x0EU);
+}
+
+void in_flight_cross_field_request_supersedes_before_confirmation() {
+  MhiCommandCoordinator coordinator{};
+  MhiCommandState command{};
+  MhiTxRuntime runtime{};
+  const auto config = make_extended_config(7U, false, true);
+
+  command.horizontal_vane_set = true;
+  command.horizontal_vane = 8U;
+  const auto first = prepare_command(coordinator, command, runtime, config);
+  stage_command(coordinator, first, command, 100U);
+
+  command.three_d_auto_set = true;
+  command.three_d_auto = false;
+  complete_command(coordinator, first, command, 150U);
+  EXPECT_TRUE(!coordinator.has_pending_confirmation());
+
+  const auto combined = prepare_command(coordinator, command, runtime, config);
+  EXPECT_TRUE(combined.result.encoded_command_mask == kMhiExtendedLouverCommandMask);
+  EXPECT_TRUE(combined.frame.data[DB16] == 0x16U);
+  EXPECT_TRUE(combined.frame.data[DB17] == 0x0BU);
+}
+
+void failed_queue_restores_both_coalesced_fields() {
+  MhiCommandCoordinator coordinator{};
+  MhiCommandState command{};
+  MhiTxRuntime runtime{};
+  const auto config = make_extended_config(7U, false, true);
+
+  command.horizontal_vane_set = true;
+  command.horizontal_vane = 8U;
+  const auto first = prepare_command(coordinator, command, runtime, config);
+  stage_command(coordinator, first, command, 100U);
+  complete_command(coordinator, first, command, 150U);
+
+  MhiCommandState patch{};
+  patch.three_d_auto_set = true;
+  patch.three_d_auto = false;
+  EXPECT_TRUE(coordinator.supersede_pending(patch) == MHI_COMMAND_HORIZONTAL_VANE);
+  command.three_d_auto_set = true;
+  command.three_d_auto = false;
+
+  const auto combined = prepare_command(coordinator, command, runtime, config);
+  EXPECT_TRUE(!command.horizontal_vane_set);
+  EXPECT_TRUE(!command.three_d_auto_set);
+  coordinator.on_stage_result(combined.envelope, combined.before, command, false, 200U);
+  EXPECT_TRUE(command.horizontal_vane_set);
+  EXPECT_TRUE(command.horizontal_vane == 8U);
+  EXPECT_TRUE(command.three_d_auto_set);
+  EXPECT_TRUE(!command.three_d_auto);
+}
+
+void same_composite_companion_does_not_supersede() {
+  MhiCommandCoordinator coordinator{};
+  MhiCommandState command{};
+  MhiTxRuntime runtime{};
+  const auto config = make_extended_config(7U, false, true);
+
+  command.horizontal_vane_set = true;
+  command.horizontal_vane = 8U;
+  const auto first = prepare_command(coordinator, command, runtime, config);
+  stage_command(coordinator, first, command, 100U);
+  complete_command(coordinator, first, command, 150U);
+
+  MhiCommandState patch{};
+  patch.three_d_auto_set = true;
+  patch.three_d_auto = true;
+  EXPECT_TRUE(coordinator.supersede_pending(patch) == 0U);
+  EXPECT_TRUE(coordinator.pending_mask() == MHI_COMMAND_HORIZONTAL_VANE);
+}
+
+void same_field_3d_replacement_remains_single_field() {
+  MhiCommandCoordinator coordinator{};
+  MhiCommandState command{};
+  MhiTxRuntime runtime{};
+  const auto config = make_extended_config(3U, false, false);
+
+  command.three_d_auto_set = true;
+  command.three_d_auto = true;
+  const auto first = prepare_command(coordinator, command, runtime, config);
+  stage_command(coordinator, first, command, 100U);
+  complete_command(coordinator, first, command, 150U);
+  EXPECT_TRUE(coordinator.pending_mask() == MHI_COMMAND_THREE_D_AUTO);
+
+  MhiCommandState patch{};
+  patch.three_d_auto_set = true;
+  patch.three_d_auto = false;
+  EXPECT_TRUE(coordinator.supersede_pending(patch) == MHI_COMMAND_THREE_D_AUTO);
+  command.three_d_auto_set = true;
+  command.three_d_auto = false;
+
+  const auto replacement = prepare_command(coordinator, command, runtime, config);
+  EXPECT_TRUE(replacement.result.encoded_command_mask == MHI_COMMAND_THREE_D_AUTO);
+  EXPECT_TRUE(replacement.frame.data[DB16] == 0x12U);
+  EXPECT_TRUE(replacement.frame.data[DB17] == 0x0AU);
+}
+
+void newest_explicit_values_override_cached_companion() {
+  MhiCommandCoordinator coordinator{};
+  MhiCommandState command{};
+  MhiTxRuntime runtime{};
+  const auto config = make_extended_config(7U, false, true);
+
+  command.horizontal_vane_set = true;
+  command.horizontal_vane = 8U;
+  const auto first = prepare_command(coordinator, command, runtime, config);
+  stage_command(coordinator, first, command, 100U);
+  complete_command(coordinator, first, command, 150U);
+
+  MhiCommandState patch{};
+  patch.three_d_auto_set = true;
+  patch.three_d_auto = false;
+  EXPECT_TRUE(coordinator.supersede_pending(patch) == MHI_COMMAND_HORIZONTAL_VANE);
+
+  // Simulate two newer requests arriving before the worker builds again.
+  command.horizontal_vane_set = true;
+  command.horizontal_vane = 5U;
+  command.three_d_auto_set = true;
+  command.three_d_auto = true;
+
+  const auto combined = prepare_command(coordinator, command, runtime, config);
+  EXPECT_TRUE(combined.result.encoded_command_mask == kMhiExtendedLouverCommandMask);
+  EXPECT_TRUE(combined.frame.data[DB16] == 0x14U);
+  EXPECT_TRUE(combined.frame.data[DB17] == 0x0EU);
+}
+
+}  // namespace
+
+void command_coordinator_extended_louver_supersession_suite() {
+  pending_horizontal_swing_plus_3d_off_coalesces_immediately();
+  pending_fixed_horizontal_plus_3d_off_coalesces_immediately();
+  pending_3d_plus_new_horizontal_preserves_3d_target();
+  in_flight_cross_field_request_supersedes_before_confirmation();
+  failed_queue_restores_both_coalesced_fields();
+  same_composite_companion_does_not_supersede();
+  same_field_3d_replacement_remains_single_field();
+  newest_explicit_values_override_cached_companion();
+}
+
+}  // namespace mhi_unit_tests

--- a/tests/unit/test_status_decoder.cpp
+++ b/tests/unit/test_status_decoder.cpp
@@ -72,13 +72,15 @@ void status_decoder_ignores_unknown_horizontal_vane_feedback() {
   frame.len = kMhiFrame33Bytes;
 
   frame.data[DB16] = 0x07U;
-  frame.data[DB17] = 0x00U;
+  frame.data[DB17] = 0x04U;
 
   MhiDecodedStatus decoded{};
   EXPECT_TRUE(MhiStatusDecoder::decode_mosi(frame.view(), decoded));
 
   EXPECT_TRUE(decoded.valid);
   EXPECT_FALSE(decoded.has_horizontal_vane);
+  EXPECT_TRUE(decoded.has_3d_auto);
+  EXPECT_TRUE(decoded.three_d_auto);
 }
 
 }  // namespace mhi_unit_tests

--- a/tests/unit/test_tx_builder_3d_auto_command_bits.cpp
+++ b/tests/unit/test_tx_builder_3d_auto_command_bits.cpp
@@ -3,94 +3,226 @@
 namespace mhi_unit_tests {
 namespace {
 
-void expect_3d_auto_command_bits(uint8_t preserved_db16, uint8_t preserved_db17,
-                                 bool horizontal_swing, uint8_t horizontal_vane,
-                                 bool requested_3d_auto, uint8_t expected_db17,
+MhiTxBuildConfig make_extended_config(uint8_t db16, uint8_t db17, bool swing, uint8_t vane, bool three_d) {
+  MhiTxBuildConfig config{};
+  config.frame_size = kMhiFrame33Bytes;
+  config.has_extended_louver_state = true;
+  config.extended_louver_db16 = db16;
+  config.extended_louver_db17 = db17;
+  config.extended_louver_horizontal_swing = swing;
+  config.extended_louver_horizontal_vane = vane;
+  config.extended_louver_three_d_auto = three_d;
+  return config;
+}
+
+MhiTxBuildResult build_extended_command(MhiCommandState& command, const MhiTxBuildConfig& config, MhiFrameBuffer& out) {
+  MhiTxRuntime runtime{};
+  MhiTxBuildResult result{};
+  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, out, result));
+  EXPECT_EQ(out.len, kMhiFrame33Bytes);
+  EXPECT_TRUE(mhi_checksum_valid_20(out.data));
+  EXPECT_TRUE(mhi_checksum_valid_33(out.data));
+  return result;
+}
+
+void expect_3d_auto_command_bits(uint8_t preserved_db16, uint8_t preserved_db17, bool horizontal_swing,
+                                 uint8_t horizontal_vane, bool requested_3d_auto, uint8_t expected_db17,
                                  uint8_t expected_intent_horizontal_vane) {
   MhiCommandState command{};
   command.three_d_auto_set = true;
   command.three_d_auto = requested_3d_auto;
-
-  MhiTxRuntime runtime{};
-
-  MhiTxBuildConfig config{};
-  config.frame_size = kMhiFrame33Bytes;
-  config.has_extended_louver_state = true;
-  config.extended_louver_db16 = preserved_db16;
-  config.extended_louver_db17 = preserved_db17;
-  config.extended_louver_horizontal_swing = horizontal_swing;
-  config.extended_louver_horizontal_vane = horizontal_vane;
-  config.extended_louver_three_d_auto = (preserved_db17 & 0x04U) != 0U;
+  const auto config = make_extended_config(preserved_db16, preserved_db17, horizontal_swing, horizontal_vane,
+                                           (preserved_db17 & 0x04U) != 0U);
 
   MhiFrameBuffer out{};
-  MhiTxBuildResult result{};
+  const auto result = build_extended_command(command, config, out);
 
-  EXPECT_TRUE(MhiTxBuilder::build_next_frame(command, runtime, config, out, result));
-
-  EXPECT_EQ(out.len, kMhiFrame33Bytes);
   EXPECT_EQ(result.encoded_command_mask, static_cast<uint32_t>(MHI_COMMAND_THREE_D_AUTO));
   EXPECT_EQ(result.unsupported_command_mask, 0U);
-
-  // The live louver position/state must be preserved while the command bits
-  // and requested 3D Auto state are applied.
   EXPECT_EQ(out.data[DB16], preserved_db16);
   EXPECT_EQ(out.data[DB17], expected_db17);
-  EXPECT_EQ(out.data[DB17] & 0x0AU, 0x0AU);  // 0x08 | 0x02 command indicators.
+  EXPECT_EQ(out.data[DB17] & 0x0AU, 0x0AU);
   EXPECT_EQ(out.data[DB17] & 0x01U, preserved_db17 & 0x01U);
   EXPECT_EQ(out.data[DB17] & 0x04U, requested_3d_auto ? 0x04U : 0x00U);
-
   EXPECT_EQ(result.intent.mask, static_cast<uint32_t>(MHI_COMMAND_THREE_D_AUTO));
   EXPECT_TRUE(result.intent.has_extended_louver_context);
   EXPECT_EQ(result.intent.horizontal_vane, expected_intent_horizontal_vane);
   EXPECT_EQ(result.intent.three_d_auto, requested_3d_auto);
-
-  EXPECT_TRUE(mhi_checksum_valid_20(out.data));
-  EXPECT_TRUE(mhi_checksum_valid_33(out.data));
   EXPECT_FALSE(command.has_pending_command());
 }
 
 void fixed_horizontal_position_3d_auto_on_uses_0x0e() {
-  expect_3d_auto_command_bits(
-      0x14U,  // Preserved fixed horizontal position.
-      0x00U,  // Fixed position, 3D Auto currently off.
-      false,
-      4U,
-      true,
-      0x0EU,
-      4U);
+  expect_3d_auto_command_bits(0x14U, 0x00U, false, 5U, true, 0x0EU, 5U);
 }
 
 void fixed_horizontal_position_3d_auto_off_uses_0x0a() {
-  expect_3d_auto_command_bits(
-      0x14U,  // Preserved fixed horizontal position.
-      0x04U,  // Fixed position, 3D Auto currently on.
-      false,
-      4U,
-      false,
-      0x0AU,
-      4U);
+  expect_3d_auto_command_bits(0x14U, 0x04U, false, 5U, false, 0x0AU, 5U);
 }
 
 void horizontal_swing_3d_auto_on_uses_0x0f() {
-  expect_3d_auto_command_bits(
-      0x1FU,  // Preserved horizontal swing context.
-      0x01U,  // Horizontal swing, 3D Auto currently off.
-      true,
-      0U,
-      true,
-      0x0FU,
-      8U);  // Intent code used by the builder for horizontal swing.
+  expect_3d_auto_command_bits(0x16U, 0x01U, true, 7U, true, 0x0FU, 8U);
 }
 
 void horizontal_swing_3d_auto_off_uses_0x0b() {
-  expect_3d_auto_command_bits(
-      0x1FU,  // Preserved horizontal swing context.
-      0x05U,  // Horizontal swing, 3D Auto currently on.
-      true,
-      0U,
-      false,
-      0x0BU,
-      8U);  // Intent code used by the builder for horizontal swing.
+  expect_3d_auto_command_bits(0x16U, 0x05U, true, 7U, false, 0x0BU, 8U);
+}
+
+void three_d_without_preserved_state_keeps_legacy_db16_fallback() {
+  MhiCommandState command{};
+  command.three_d_auto_set = true;
+  command.three_d_auto = true;
+  MhiTxBuildConfig config{};
+  config.frame_size = kMhiFrame33Bytes;
+
+  MhiFrameBuffer out{};
+  const auto result = build_extended_command(command, config, out);
+
+  EXPECT_EQ(out.data[DB16], 0x00U);
+  EXPECT_EQ(out.data[DB17], 0x0EU);
+  EXPECT_EQ(result.intent.horizontal_vane, 1U);
+  EXPECT_TRUE(result.intent.three_d_auto);
+  EXPECT_FALSE(result.intent.has_extended_louver_context);
+}
+
+void horizontal_without_preserved_state_carries_transmitted_composite_context() {
+  MhiCommandState command{};
+  command.horizontal_vane_set = true;
+  command.horizontal_vane = 4U;
+  MhiTxBuildConfig config{};
+  config.frame_size = kMhiFrame33Bytes;
+
+  MhiFrameBuffer out{};
+  const auto result = build_extended_command(command, config, out);
+
+  EXPECT_EQ(out.data[DB16], 0x13U);
+  EXPECT_EQ(out.data[DB17], 0x0AU);
+  EXPECT_EQ(result.intent.horizontal_vane, 4U);
+  EXPECT_FALSE(result.intent.three_d_auto);
+  EXPECT_TRUE(result.intent.has_extended_louver_context);
+}
+
+void horizontal_fixed_write_preserves_3d_auto_on() {
+  MhiCommandState command{};
+  command.horizontal_vane_set = true;
+  command.horizontal_vane = 4U;
+  const auto config = make_extended_config(0x12U, 0x0EU, false, 3U, true);
+
+  MhiFrameBuffer out{};
+  const auto result = build_extended_command(command, config, out);
+
+  EXPECT_EQ(result.encoded_command_mask, static_cast<uint32_t>(MHI_COMMAND_HORIZONTAL_VANE));
+  EXPECT_EQ(out.data[DB16], 0x13U);
+  EXPECT_EQ(out.data[DB17], 0x0EU);
+  EXPECT_TRUE(result.intent.has_extended_louver_context);
+  EXPECT_EQ(result.intent.horizontal_vane, 4U);
+  EXPECT_TRUE(result.intent.three_d_auto);
+}
+
+void horizontal_swing_write_preserves_3d_auto_on_and_last_position() {
+  MhiCommandState command{};
+  command.horizontal_vane_set = true;
+  command.horizontal_vane = 8U;
+  const auto config = make_extended_config(0x14U, 0x0EU, false, 5U, true);
+
+  MhiFrameBuffer out{};
+  const auto result = build_extended_command(command, config, out);
+
+  EXPECT_EQ(result.encoded_command_mask, static_cast<uint32_t>(MHI_COMMAND_HORIZONTAL_VANE));
+  EXPECT_EQ(out.data[DB16], 0x14U);
+  EXPECT_EQ(out.data[DB17], 0x0FU);
+  EXPECT_EQ(result.intent.horizontal_vane, 8U);
+  EXPECT_TRUE(result.intent.three_d_auto);
+}
+
+void combined_horizontal_and_3d_command_encodes_one_composite_state() {
+  MhiCommandState command{};
+  command.horizontal_vane_set = true;
+  command.horizontal_vane = 6U;
+  command.three_d_auto_set = true;
+  command.three_d_auto = false;
+  const auto config = make_extended_config(0x11U, 0x0EU, false, 2U, true);
+
+  MhiFrameBuffer out{};
+  const auto result = build_extended_command(command, config, out);
+
+  EXPECT_EQ(result.encoded_command_mask,
+            static_cast<uint32_t>(MHI_COMMAND_HORIZONTAL_VANE | MHI_COMMAND_THREE_D_AUTO));
+  EXPECT_EQ(result.intent.mask, static_cast<uint32_t>(MHI_COMMAND_HORIZONTAL_VANE | MHI_COMMAND_THREE_D_AUTO));
+  EXPECT_EQ(out.data[DB16], 0x15U);
+  EXPECT_EQ(out.data[DB17], 0x0AU);
+  EXPECT_EQ(result.intent.horizontal_vane, 6U);
+  EXPECT_FALSE(result.intent.three_d_auto);
+}
+
+MhiStatusState make_extended_status(uint8_t horizontal_vane, bool swing, bool three_d) {
+  MhiStatusState status{};
+  status.valid = true;
+  status.has_horizontal_vane = true;
+  status.horizontal_vane = horizontal_vane;
+  status.horizontal_vane_swing = swing;
+  status.has_3d_auto = true;
+  status.three_d_auto = three_d;
+  return status;
+}
+
+void horizontal_confirmation_requires_preserved_3d_state() {
+  MhiCommandConfirmation confirmation{};
+  MhiCommandIntent intent{};
+  intent.mask = MHI_COMMAND_HORIZONTAL_VANE;
+  intent.horizontal_vane = 4U;
+  intent.three_d_auto = true;
+  intent.has_extended_louver_context = true;
+  confirmation.stage(intent, MHI_COMMAND_HORIZONTAL_VANE, 100U);
+
+  auto status = make_extended_status(4U, false, false);
+  EXPECT_EQ(confirmation.observe_status(status), 0U);
+  EXPECT_TRUE(confirmation.has_pending());
+
+  status.three_d_auto = true;
+  EXPECT_EQ(confirmation.observe_status(status), static_cast<uint32_t>(MHI_COMMAND_HORIZONTAL_VANE));
+  EXPECT_FALSE(confirmation.has_pending());
+}
+
+void three_d_confirmation_ignores_preserved_horizontal_state() {
+  MhiCommandConfirmation confirmation{};
+  MhiCommandIntent intent{};
+  intent.mask = MHI_COMMAND_THREE_D_AUTO;
+  intent.horizontal_vane = 4U;
+  intent.three_d_auto = true;
+  intent.has_extended_louver_context = true;
+  confirmation.stage(intent, MHI_COMMAND_THREE_D_AUTO, 100U);
+
+  const auto status = make_extended_status(5U, false, true);
+  EXPECT_EQ(confirmation.observe_status(status), static_cast<uint32_t>(MHI_COMMAND_THREE_D_AUTO));
+  EXPECT_FALSE(confirmation.has_pending());
+}
+
+void swing_confirmation_ignores_retained_position() {
+  MhiCommandConfirmation confirmation{};
+  MhiCommandIntent intent{};
+  intent.mask = MHI_COMMAND_HORIZONTAL_VANE;
+  intent.horizontal_vane = 8U;
+  intent.three_d_auto = true;
+  intent.has_extended_louver_context = true;
+  confirmation.stage(intent, MHI_COMMAND_HORIZONTAL_VANE, 100U);
+
+  const auto status = make_extended_status(7U, true, true);
+  EXPECT_EQ(confirmation.observe_status(status), static_cast<uint32_t>(MHI_COMMAND_HORIZONTAL_VANE));
+}
+
+void three_d_timeout_retries_inside_matrix_case() {
+  MhiCommandConfirmation confirmation{};
+  MhiCommandIntent intent{};
+  intent.mask = MHI_COMMAND_THREE_D_AUTO;
+  intent.horizontal_vane = 3U;
+  intent.three_d_auto = true;
+  intent.has_extended_louver_context = true;
+  confirmation.stage(intent, MHI_COMMAND_THREE_D_AUTO, 100U);
+
+  EXPECT_FALSE(confirmation.expire(100U + kMhiThreeDAutoConfirmationTimeoutMs - 1U).expired());
+  const auto expiration = confirmation.expire(100U + kMhiThreeDAutoConfirmationTimeoutMs);
+  EXPECT_TRUE(expiration.expired());
+  EXPECT_EQ(expiration.mask, static_cast<uint32_t>(MHI_COMMAND_THREE_D_AUTO));
 }
 
 }  // namespace
@@ -100,6 +232,15 @@ void tx_builder_3d_auto_command_bits_regression_suite() {
   fixed_horizontal_position_3d_auto_off_uses_0x0a();
   horizontal_swing_3d_auto_on_uses_0x0f();
   horizontal_swing_3d_auto_off_uses_0x0b();
+  three_d_without_preserved_state_keeps_legacy_db16_fallback();
+  horizontal_without_preserved_state_carries_transmitted_composite_context();
+  horizontal_fixed_write_preserves_3d_auto_on();
+  horizontal_swing_write_preserves_3d_auto_on_and_last_position();
+  combined_horizontal_and_3d_command_encodes_one_composite_state();
+  horizontal_confirmation_requires_preserved_3d_state();
+  three_d_confirmation_ignores_preserved_horizontal_state();
+  swing_confirmation_ignores_retained_position();
+  three_d_timeout_retries_inside_matrix_case();
 }
 
 }  // namespace mhi_unit_tests


### PR DESCRIPTION
# fix: preserve and coalesce composite louver/3D Auto state

## Summary

This PR hardens horizontal-vane and 3D Auto command handling for 33-byte MHI units.

Horizontal vane and 3D Auto share the DB16/DB17 command domain. The implementation now treats them as one composite desired state, preserves the companion field when only one setting changes, and immediately coalesces newer intent when an older confirmation is still pending.

This resolves the sequencing issue where a pending horizontal confirmation could block a newer 3D request until timeout and allow stale state to carry into the next command.

## Changes

- Preserve the current 3D Auto bit when sending a horizontal-only command.
- Preserve the current horizontal position or swing state when sending a 3D-only command.
- Supersede stale pending horizontal/3D confirmation generations when newer cross-field intent changes the desired composite state.
- Retransmit the latest horizontal + 3D target immediately as a combined `0x60` command.
- Retain coalesced intent across transport queue or TX completion failures.
- Confirm horizontal commands against:
  - the requested fixed position or swing state; and
  - the preserved 3D companion state encoded in the command.
- Confirm 3D Auto independently from DB17 bit `0x04`.
- Ignore retained fixed-position bits when confirming vertical or horizontal swing.
- Decode 3D Auto independently when DB16 contains an unknown horizontal position.
- Suppress duplicate or already-confirmed vertical-vane requests.
- Reduce horizontal and 3D confirmation windows from 20 seconds to 3 seconds before retry.
- Add focused regression coverage for composite encoding, confirmation semantics, retries, queue failures, and pending/in-flight supersession.

## Protocol behaviour

The confirmed DB16/DB17 mapping is preserved:

| Horizontal state | 3D Auto OFF | 3D Auto ON |
|---|---:|---:|
| Fixed position | `DB17=0x0A` | `DB17=0x0E` |
| Swing | `DB17=0x0B` | `DB17=0x0F` |

3D Auto is DB17 bit `0x04`.

For swing states, the unit retains the previous fixed position in DB1 or DB16. Confirmation therefore checks the swing bit and deliberately ignores the retained position value.

## Supersession flow

When a horizontal command is awaiting confirmation and a newer 3D request changes the desired DB16/DB17 state, the coordinator now performs the following flow:

```text
confirmed state
+ pending intent
+ newly staged intent
= latest desired composite state
```

The stale confirmation generation is settled, and the latest composite state is transmitted immediately:

```text
pending horizontal 0x20
+ newer 3D request
-> supersede pending horizontal confirmation
-> transmit combined 0x60 command
-> start a new confirmation generation
```

## Validation

### Unit tests

```text
./scripts/test.sh
MHI protocol unit tests passed
7 Python tests passed
```

### Sanitizers

```text
SANITIZERS=1 ./scripts/test.sh
MHI protocol unit tests passed
7 Python tests passed
```

### Hardware matrix

The complete louver matrix passed all 80 combinations:

- Vertical vane: `80/80`
- Horizontal vane: `80/80`
- 3D Auto: `80/80`
- Complete requested state: `80/80`
- Retry exhaustions: `0`
- Pending confirmation mask at completion: `0x00000000`

The hardware run also exercised pending horizontal-to-3D supersession. Each occurrence generated a combined `0x60` command and confirmed the latest composite state without leaking stale intent into the next matrix case.

Three transient 3D confirmation timeouts occurred during the complete run. Each recovered after one retry using the new 3-second confirmation window.

Transport remained clean during the matrix and subsequent soak:

- Invalid frames: `0`
- Checksum failures: `0`
- Signature misses: `0`
- Sync losses: `0`
- Dropped bytes: `0`
- TX failures: `0`
- Queue errors: `0`
- RMT re-arm errors: `0`
- RX overwrites: `0`
- Completion drops: `0`

## Scope

This PR intentionally excludes:

- `mhi_louver_diag` and matrix diagnostic instrumentation;
- RMT/SPI transport backend changes;
- non-DMA driver work;
- driver-selection changes; and
- unrelated spike logging.

The change set is limited to production louver/3D command building, coordination, confirmation, decoding, duplicate suppression, and regression tests.

## Compatibility and risk

- The composite DB16/DB17 path applies only when extended louver state is available.
- Existing non-extended command handling is unchanged.
- The main behavioural change is that newer horizontal/3D intent now takes precedence immediately instead of waiting for an obsolete confirmation timeout.
- The shorter timeout may produce an earlier retry when the unit ignores a command, but successful hardware confirmations were normally observed within approximately 100-250 ms.

## Checklist

- [x] Composite horizontal/3D state preserved
- [x] Pending and in-flight cross-field supersession covered
- [x] Swing confirmation uses semantic state
- [x] Vertical duplicate suppression covered
- [x] Unit tests pass
- [x] Address/undefined sanitizer tests pass
- [x] Full 80-case hardware matrix passes
- [x] Spike-only diagnostics excluded
- [x] ESPHome compile and repository lint checks to be confirmed by CI